### PR TITLE
Guard M3U import example for non-Windows builds

### DIFF
--- a/sdk/example_m3u/import_m3u.cpp
+++ b/sdk/example_m3u/import_m3u.cpp
@@ -26,8 +26,13 @@
 
   */
 
-
+#ifdef _WIN32
 #include <windows.h>
+#include <string.h>
+#else
+#include "../../WDL/swell/swell.h"
+#include <strings.h>
+#endif
 #include <stdio.h>
 #include <math.h>
 
@@ -46,7 +51,12 @@ PCM_source *(*PCM_Source_CreateFromFile)(const char *filename);
 
 bool WantProjectFile(const char *fn)
 {
-  return strlen(fn)>4 && !stricmp(fn+strlen(fn)-4,".m3u");
+  return strlen(fn)>4 &&
+#ifdef _WIN32
+    !_stricmp(fn+strlen(fn)-4,".m3u");
+#else
+    !strcasecmp(fn+strlen(fn)-4,".m3u");
+#endif
 }
 
   // this is used for UI only


### PR DESCRIPTION
## Summary
- Guard <windows.h> include behind _WIN32 and add SWELL headers on other platforms
- Use _stricmp/strcasecmp so WantProjectFile works cross-platform

## Testing
- `g++ -shared -fPIC -DNOMINMAX -fpermissive sdk/example_m3u/import_m3u.cpp -o sdk/example_m3u/import_m3u.so`
- `g++ -DNOMINMAX test_import.cpp -o test_import -ldl`
- `./test_import`


------
https://chatgpt.com/codex/tasks/task_e_689646cf1984832cafc91575615aca61