### PR TITLE
Add CMake build system for sample REAPER plug-ins

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,79 @@
+cmake_minimum_required(VERSION 3.15)
+project(reaper_sdk LANGUAGES C CXX)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Expose SDK headers
+add_library(reaper_sdk_headers INTERFACE)
+target_include_directories(reaper_sdk_headers INTERFACE
+    ${CMAKE_CURRENT_SOURCE_DIR}/sdk
+    ${CMAKE_CURRENT_SOURCE_DIR}/reaper-plugins
+)
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/WDL")
+    target_include_directories(reaper_sdk_headers INTERFACE
+        ${CMAKE_CURRENT_SOURCE_DIR}/WDL
+    )
+endif()
+
+# example_m3u plug-in (Windows only)
+if(WIN32)
+    add_library(example_m3u MODULE sdk/example_m3u/import_m3u.cpp)
+    target_link_libraries(example_m3u PRIVATE reaper_sdk_headers)
+    set_target_properties(example_m3u PROPERTIES PREFIX "")
+endif()
+
+# example_raw plug-in
+add_library(example_raw MODULE
+    sdk/example_raw/pcmsink_raw.cpp
+    sdk/example_raw/pcmsrc_raw.cpp
+)
+target_link_libraries(example_raw PRIVATE reaper_sdk_headers)
+set_target_properties(example_raw PROPERTIES PREFIX "")
+if(WIN32)
+    target_sources(example_raw PRIVATE sdk/example_raw/res.rc)
+endif()
+
+# reaper_csurf plug-in
+add_library(reaper_csurf MODULE
+    reaper-plugins/reaper_csurf/csurf_01X.cpp
+    reaper-plugins/reaper_csurf/csurf_alphatrack.cpp
+    reaper-plugins/reaper_csurf/csurf_babyhui.cpp
+    reaper-plugins/reaper_csurf/csurf_bcf2000.cpp
+    reaper-plugins/reaper_csurf/csurf_faderport.cpp
+    reaper-plugins/reaper_csurf/csurf_faderport2.cpp
+    reaper-plugins/reaper_csurf/csurf_main.cpp
+    reaper-plugins/reaper_csurf/csurf_mcu.cpp
+    reaper-plugins/reaper_csurf/csurf_osc.cpp
+    reaper-plugins/reaper_csurf/csurf_tranzport.cpp
+    reaper-plugins/reaper_csurf/csurf_www.cpp
+    reaper-plugins/reaper_csurf/osc.cpp
+    reaper-plugins/reaper_csurf/osc_message.cpp
+)
+target_link_libraries(reaper_csurf PRIVATE reaper_sdk_headers)
+set_target_properties(reaper_csurf PROPERTIES PREFIX "")
+if(WIN32)
+    target_sources(reaper_csurf PRIVATE reaper-plugins/reaper_csurf/res.rc)
+endif()
+
+# reaper_mp3 plug-in
+add_library(reaper_mp3 MODULE
+    reaper-plugins/reaper_mp3/mp3dec.cpp
+    reaper-plugins/reaper_mp3/mp3_index.cpp
+    reaper-plugins/reaper_mp3/pcmsink_mp3lame.cpp
+    reaper-plugins/reaper_mp3/pcmsrc_mp3dec.cpp
+    reaper-plugins/reaper_mp3/mpglib/common.cpp
+    reaper-plugins/reaper_mp3/mpglib/interface.cpp
+    reaper-plugins/reaper_mp3/mpglib/layer2.cpp
+    reaper-plugins/reaper_mp3/mpglib/layer3.cpp
+    reaper-plugins/reaper_mp3/mpglib/StdAfx.cpp
+    reaper-plugins/reaper_mp3/mpglib/tabinit.cpp
+    reaper-plugins/reaper_mp3/mpglib/dct64_i386.cpp
+    reaper-plugins/reaper_mp3/mpglib/decode_i386.cpp
+)
+target_link_libraries(reaper_mp3 PRIVATE reaper_sdk_headers)
+set_target_properties(reaper_mp3 PROPERTIES PREFIX "")
+if(WIN32)
+    target_sources(reaper_mp3 PRIVATE reaper-plugins/reaper_mp3/res.rc)
+endif()
+

--- a/README
+++ b/README
@@ -16,3 +16,25 @@ To compile most of this, merge or symlink in WDL:
 git remote add wdl https://github.com/justinfrankel/WDL.git
 git fetch --all
 git merge --allow-unrelated-histories wdl/main
+
+Building with CMake
+-------------------
+
+This repository includes a top-level CMake project that exposes the SDK
+headers and builds a few sample plug-ins.  After cloning or linking the
+WDL directory as described above, generate build files for your platform:
+
+```
+cmake -S . -B build
+cmake --build build
+```
+
+Specific targets can be built by name using `cmake --build build --target <name>`.
+The available sample targets are:
+
+* `example_m3u` (Windows only)
+* `example_raw`
+* `reaper_csurf`
+* `reaper_mp3`
+
+Use CMake's `-G` option to select a generator for your compiler or IDE.


### PR DESCRIPTION
## Summary
- Add top-level CMake project exposing SDK headers and building sample plug-ins
- Document how to configure and build the examples with CMake

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: ‘WDL_INT64’ has not been declared)*

------
https://chatgpt.com/codex/tasks/task_e_689646dd1a80832cb0da0ee627268a55