### PR TITLE
Add REAPER API loader wrapper

### DIFF
--- a/sdk/example_m3u/import_m3u.cpp
+++ b/sdk/example_m3u/import_m3u.cpp
@@ -33,14 +33,14 @@
 
 
 #include "../reaper_plugin.h"
+#include "../reaper_api_loader.hpp"
 
 
 REAPER_PLUGIN_HINSTANCE g_hInst; // used for dialogs, if any
 
-// these are used to resolve/make relative pathnames 
-void (*resolve_fn)(const char *in, char *out, int outlen);
-void (*relative_fn)(const char *in, char *out, int outlen);
-PCM_source *(*PCM_Source_CreateFromFile)(const char *filename);
+// these are used to resolve/make relative pathnames
+// resolve_fn, relative_fn and PCM_Source_CreateFromFile are provided by REAPER
+// and will be loaded via ReaperAPILoader.
 
 
 
@@ -153,16 +153,13 @@ REAPER_PLUGIN_DLL_EXPORT int REAPER_PLUGIN_ENTRYPOINT(REAPER_PLUGIN_HINSTANCE hI
   g_hInst=hInstance;
   if (rec)
   {
-    if (rec->caller_version != REAPER_PLUGIN_VERSION || !rec->GetFunc)
+    ReaperAPILoader api(rec);
+    if (!api)
       return 0;
 
-    *((void **)&resolve_fn) = rec->GetFunc("resolve_fn");   
-    *((void **)&relative_fn) = rec->GetFunc("relative_fn");   
-    *((void **)&PCM_Source_CreateFromFile) = rec->GetFunc("PCM_Source_CreateFromFile");
-
-    if (!resolve_fn || 
-      !PCM_Source_CreateFromFile || 
-      !rec->Register ||      
+    if (!resolve_fn ||
+      !PCM_Source_CreateFromFile ||
+      !rec->Register ||
       !rec->Register("projectimport",&myRegStruct))
       return 0;
 

--- a/sdk/example_raw/pcmsrc_raw.cpp
+++ b/sdk/example_raw/pcmsrc_raw.cpp
@@ -36,6 +36,7 @@
 #include <math.h>
 
 #include "resource.h"
+#include "../reaper_api_loader.hpp"
 
 #define REAPERAPI_IMPLEMENT
 #define REAPERAPI_MINIMAL
@@ -299,7 +300,8 @@ REAPER_PLUGIN_DLL_EXPORT int REAPER_PLUGIN_ENTRYPOINT(REAPER_PLUGIN_HINSTANCE hI
   g_hInst=hInstance;
   if (rec)
   {
-    if (rec->caller_version != REAPER_PLUGIN_VERSION || !rec->GetFunc || REAPERAPI_LoadAPI(rec->GetFunc))
+    ReaperAPILoader api(rec);
+    if (!api)
       return 0;
 
     if (!rec->Register || 

--- a/sdk/reaper_api_loader.hpp
+++ b/sdk/reaper_api_loader.hpp
@@ -1,0 +1,51 @@
+#ifndef REAPER_API_LOADER_HPP
+#define REAPER_API_LOADER_HPP
+
+#include "reaper_plugin.h"
+#include "reaper_plugin_functions.h"
+#include <utility>
+
+class ReaperAPILoader {
+public:
+  using get_api_t = void *(*)(const char *);
+
+  template <typename Sig> class Function;
+
+  template <typename Ret, typename... Args> class Function<Ret(Args...)> {
+  public:
+    using Fn = Ret (*)(Args...);
+    Function() : fn_(nullptr) {}
+    Function(get_api_t api, const char *name) { load(api, name); }
+    bool load(get_api_t api, const char *name) {
+      fn_ = api ? reinterpret_cast<Fn>(api(name)) : nullptr;
+      return fn_ != nullptr;
+    }
+    bool valid() const { return fn_ != nullptr; }
+    explicit operator bool() const { return valid(); }
+    Ret operator()(Args... args) const { return fn_(args...); }
+
+  private:
+    Fn fn_;
+  };
+
+  explicit ReaperAPILoader(reaper_plugin_info_t *rec) : api_(nullptr), ok_(false) {
+    if (!rec || rec->caller_version != REAPER_PLUGIN_VERSION || !rec->GetFunc)
+      return;
+    api_ = rec->GetFunc;
+    ok_ = (REAPERAPI_LoadAPI(api_) == 0);
+  }
+  ~ReaperAPILoader() = default;
+
+  bool ok() const { return ok_; }
+  explicit operator bool() const { return ok_; }
+
+  template <typename Sig> Function<Sig> load(const char *name) const {
+    return Function<Sig>(api_, name);
+  }
+
+private:
+  get_api_t api_;
+  bool ok_;
+};
+
+#endif


### PR DESCRIPTION
## Summary
- add reusable `ReaperAPILoader` wrapper to call `REAPERAPI_LoadAPI` and fetch typed functions
- migrate example plug-ins to use `ReaperAPILoader` instead of manual `GetFunc` and error handling

## Testing
- `x86_64-w64-mingw32-g++ -std=c++11 -Isdk -c sdk/example_m3u/import_m3u.cpp -o /tmp/import_m3u.o` *(fails: ‘WDL_INT64’ has not been declared)*
- `x86_64-w64-mingw32-g++ -std=c++11 -Isdk -c sdk/example_raw/pcmsrc_raw.cpp -o /tmp/pcmsrc_raw.o` *(fails: fatal error: ../../WDL/fileread.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689646ebad68832c88748e73d5a174ef