### PR TITLE
Add timecode module with LTC/MTC helpers

### DIFF
--- a/sdk/reaper_plugin_functions.h
+++ b/sdk/reaper_plugin_functions.h
@@ -7647,6 +7647,22 @@ REAPERAPI_DEF //==============================================
   void (*REAPERAPI_FUNCNAME(Undo_OnStateChangeEx2))(ReaProject* proj, const char* descchange, int whichStates, int trackparm);
 #endif
 
+#if defined(REAPERAPI_WANT_RegisterTimecodeInput) || !defined(REAPERAPI_MINIMAL)
+REAPERAPI_DEF //==============================================
+// RegisterTimecodeInput
+// Register a callback to receive decoded timecode frames.
+
+  void (*REAPERAPI_FUNCNAME(RegisterTimecodeInput))(void (*cb)(const char* frame, double seconds));
+#endif
+
+#if defined(REAPERAPI_WANT_SendTimecodeFrame) || !defined(REAPERAPI_MINIMAL)
+REAPERAPI_DEF //==============================================
+// SendTimecodeFrame
+// Transmit a timecode frame from REAPER.
+
+  void (*REAPERAPI_FUNCNAME(SendTimecodeFrame))(const char* frame);
+#endif
+
 #if defined(REAPERAPI_WANT_update_disk_counters) || !defined(REAPERAPI_MINIMAL)
 REAPERAPI_DEF //==============================================
 // update_disk_counters
@@ -10261,6 +10277,12 @@ REAPERAPI_DEF //==============================================
       #endif
       #if defined(REAPERAPI_WANT_Undo_OnStateChangeEx2) || !defined(REAPERAPI_MINIMAL)
         {(void**)&REAPERAPI_FUNCNAME(Undo_OnStateChangeEx2),"Undo_OnStateChangeEx2"},
+      #endif
+      #if defined(REAPERAPI_WANT_RegisterTimecodeInput) || !defined(REAPERAPI_MINIMAL)
+        {(void**)&REAPERAPI_FUNCNAME(RegisterTimecodeInput),"RegisterTimecodeInput"},
+      #endif
+      #if defined(REAPERAPI_WANT_SendTimecodeFrame) || !defined(REAPERAPI_MINIMAL)
+        {(void**)&REAPERAPI_FUNCNAME(SendTimecodeFrame),"SendTimecodeFrame"},
       #endif
       #if defined(REAPERAPI_WANT_update_disk_counters) || !defined(REAPERAPI_MINIMAL)
         {(void**)&REAPERAPI_FUNCNAME(update_disk_counters),"update_disk_counters"},

--- a/sdk/timecode.cpp
+++ b/sdk/timecode.cpp
@@ -1,0 +1,79 @@
+#include "timecode.h"
+#include <cstring>
+
+namespace reaper {
+namespace timecode {
+
+static inline uint8_t to_bcd(int v) {
+    return ((v / 10) << 4) | (v % 10);
+}
+
+static inline int from_bcd(uint8_t v) {
+    return (v >> 4) * 10 + (v & 0x0F);
+}
+
+void EncodeLTC(const Frame &src, uint8_t out[10]) {
+    std::memset(out, 0, 10);
+    out[0] = to_bcd(src.frames);
+    out[1] = to_bcd(src.seconds);
+    out[2] = to_bcd(src.minutes);
+    out[3] = to_bcd(src.hours);
+}
+
+bool DecodeLTC(const uint8_t in[10], Frame *out) {
+    if (!out) return false;
+    out->frames  = from_bcd(in[0]);
+    out->seconds = from_bcd(in[1]);
+    out->minutes = from_bcd(in[2]);
+    out->hours   = from_bcd(in[3]);
+    return true;
+}
+
+void EncodeMTC(const Frame &src, uint8_t out[8]) {
+    const int fpsCode = src.rate == FrameRate::FPS24 ? 0 :
+                        src.rate == FrameRate::FPS25 ? 1 :
+                        src.rate == FrameRate::FPS30_DROP ? 2 : 3;
+    out[0] = (0x0 << 4) | (src.frames & 0x0F);
+    out[1] = (0x1 << 4) | ((src.frames >> 4) & 0x01);
+    out[2] = (0x2 << 4) | (src.seconds & 0x0F);
+    out[3] = (0x3 << 4) | ((src.seconds >> 4) & 0x03);
+    out[4] = (0x4 << 4) | (src.minutes & 0x0F);
+    out[5] = (0x5 << 4) | ((src.minutes >> 4) & 0x03);
+    out[6] = (0x6 << 4) | (src.hours & 0x0F);
+    out[7] = (0x7 << 4) | ((src.hours >> 4) & 0x01) | (fpsCode << 1);
+}
+
+bool DecodeMTC(const uint8_t in[8], Frame *out) {
+    if (!out) return false;
+    out->frames  = (in[1] & 0x01) << 4 | (in[0] & 0x0F);
+    out->seconds = (in[3] & 0x03) << 4 | (in[2] & 0x0F);
+    out->minutes = (in[5] & 0x03) << 4 | (in[4] & 0x0F);
+    out->hours   = (in[7] & 0x01) << 4 | (in[6] & 0x0F);
+    const int fpsCode = (in[7] >> 1) & 0x3;
+    out->rate = fpsCode == 0 ? FrameRate::FPS24 :
+                fpsCode == 1 ? FrameRate::FPS25 :
+                fpsCode == 2 ? FrameRate::FPS30_DROP : FrameRate::FPS30;
+    return true;
+}
+
+double ToSeconds(const Frame &tc) {
+    const double fps = static_cast<int>(tc.rate);
+    return tc.hours * 3600.0 + tc.minutes * 60.0 + tc.seconds + tc.frames / fps;
+}
+
+Frame FromSeconds(double seconds, FrameRate rate) {
+    Frame out;
+    out.rate = rate;
+    const double fps = static_cast<int>(rate);
+    out.hours = static_cast<int>(seconds / 3600.0);
+    seconds -= out.hours * 3600.0;
+    out.minutes = static_cast<int>(seconds / 60.0);
+    seconds -= out.minutes * 60.0;
+    out.seconds = static_cast<int>(seconds);
+    seconds -= out.seconds;
+    out.frames = static_cast<int>(seconds * fps);
+    return out;
+}
+
+} // namespace timecode
+} // namespace reaper

--- a/sdk/timecode.h
+++ b/sdk/timecode.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <cstdint>
+#include <cstddef>
+
+namespace reaper {
+namespace timecode {
+
+// Enumeration of supported frame rates.
+enum class FrameRate {
+    FPS24 = 24,
+    FPS25 = 25,
+    FPS30 = 30,
+    FPS30_DROP = 29
+};
+
+// SMPTE timecode frame representation.
+struct Frame {
+    int hours{0};
+    int minutes{0};
+    int seconds{0};
+    int frames{0};
+    FrameRate rate{FrameRate::FPS30};
+};
+
+// Encode an LTC frame into 80 bits (10 bytes).
+void EncodeLTC(const Frame &src, uint8_t out[10]);
+// Decode an LTC frame from 80 bits (10 bytes). Returns false on failure.
+bool DecodeLTC(const uint8_t in[10], Frame *out);
+
+// Encode an MTC frame as eight quarter-frame messages.
+void EncodeMTC(const Frame &src, uint8_t out[8]);
+// Decode an MTC frame from eight quarter-frame messages.
+bool DecodeMTC(const uint8_t in[8], Frame *out);
+
+// Convert a timecode frame to seconds relative to start.
+double ToSeconds(const Frame &tc);
+// Generate a timecode frame from seconds.
+Frame FromSeconds(double seconds, FrameRate rate);
+
+// Utility helpers for transport synchronisation.
+inline double SyncToIncoming(const Frame &tc) { return ToSeconds(tc); }
+inline Frame SyncToOutgoing(double position, FrameRate rate) { return FromSeconds(position, rate); }
+
+} // namespace timecode
+} // namespace reaper


### PR DESCRIPTION
## Summary
- Add dedicated timecode module with LTC and MTC encode/decode helpers
- Expose RegisterTimecodeInput and SendTimecodeFrame callbacks through plugin API
- Provide helpers for syncing transport position to timecode values

## Testing
- `make` *(fails: No targets specified and no makefile found)*
- `g++ -std=c++17 -c sdk/timecode.cpp -o /tmp/timecode.o`
- `ls -l /tmp/timecode.o`

------
https://chatgpt.com/codex/tasks/task_e_68966bc66cd4832c8e16f4af9ab374ca