### PR TITLE
Add speech-to-text utilities using PCM source blocks

### DIFF
--- a/README
+++ b/README
@@ -4,8 +4,11 @@ Paths:
 
 sdk/             -- contains headers to use
 reaper-plugins/  -- contains source to some plug-ins which are included with REAPER
-                    (these are not to be used as models for well-designed plug-ins, 
+                    (these are not to be used as models for well-designed plug-ins,
                     but they may be useful and/or available for LGPL compliance ;)
+                    The `stt_utils` helper demonstrates how to feed
+                    `PCM_source_transfer_t` blocks to a speech-to-text engine and
+                    annotate a project with word markers.
 
 Paths that should be added in order to compile:
 

--- a/reaper-plugins/stt_utils.cpp
+++ b/reaper-plugins/stt_utils.cpp
@@ -1,0 +1,79 @@
+#include "stt_utils.h"
+
+#include <algorithm>
+
+// REAPER API function pointers that will be provided by the host at runtime.
+// Only the subset required for this utility is declared here.
+extern int (*AddProjectMarker)(ReaProject* proj, bool isrgn, double pos,
+                               double rgnend, const char* name, int wantidx);
+extern bool (*SetProjectMarkerByIndex2)(ReaProject* proj, int markrgnidx,
+                                        bool isrgn, double pos, double rgnend,
+                                        int IDnumber, const char* name,
+                                        int color, int flags);
+
+// ----------------------------------------------------------------------------
+// LocalSTTEngine
+// ----------------------------------------------------------------------------
+
+void LocalSTTEngine::Feed(const PCM_source_transfer_t* block)
+{
+  // In a production system, this function would pass the audio contained in
+  // |block| to a speech-to-text engine.  The mini-SDK does not include such an
+  // engine, so the implementation is intentionally left empty.
+  (void)block; // suppress unused parameter warning
+}
+
+// ----------------------------------------------------------------------------
+// STTTranscriber
+// ----------------------------------------------------------------------------
+
+STTTranscriber::STTTranscriber(ReaProject* project)
+  : project_(project)
+{
+}
+
+void STTTranscriber::ProcessBlock(PCM_source_transfer_t* block)
+{
+  stt_.Feed(block);
+}
+
+void STTTranscriber::AddWord(const std::string& word, double position)
+{
+  int id = AddProjectMarker(project_, false, position, position, word.c_str(), -1);
+  markers_.push_back({position, word, id});
+  if (!transcript_.empty()) transcript_ += ' ';
+  transcript_ += word;
+}
+
+std::vector<WordMarker> STTTranscriber::Search(const std::string& target) const
+{
+  std::vector<WordMarker> results;
+  for (const auto& m : markers_) {
+    if (m.word == target) {
+      results.push_back(m);
+    }
+  }
+  return results;
+}
+
+void STTTranscriber::ReplaceWord(const std::string& target,
+                                 const std::string& replacement)
+{
+  for (auto& m : markers_) {
+    if (m.word == target) {
+      m.word = replacement;
+      // Update the marker's name inside the project.
+      SetProjectMarkerByIndex2(project_, m.marker_id, false, m.position,
+                               m.position, m.marker_id, replacement.c_str(), 0,
+                               0);
+    }
+  }
+
+  // Rebuild transcript from markers.
+  transcript_.clear();
+  for (const auto& m : markers_) {
+    if (!transcript_.empty()) transcript_ += ' ';
+    transcript_ += m.word;
+  }
+}
+

--- a/reaper-plugins/stt_utils.h
+++ b/reaper-plugins/stt_utils.h
@@ -1,0 +1,54 @@
+#ifndef REAPER_STT_UTILS_H
+#define REAPER_STT_UTILS_H
+
+#include "reaper_plugin.h"
+#include <string>
+#include <vector>
+
+// Simple struct representing a word marker inserted into the project.
+struct WordMarker {
+  double position;       // Start time in seconds
+  std::string word;      // Recognized word
+  int marker_id;         // Marker ID as returned by AddProjectMarker
+};
+
+// Minimal local speech-to-text engine interface.  This class simply
+// collects audio blocks and would be replaced by a real STT engine in a
+// complete implementation.
+class LocalSTTEngine {
+public:
+  // Feed a block of audio to the engine.  In a real implementation this
+  // would perform recognition on the audio contained in the block.
+  void Feed(const PCM_source_transfer_t* block);
+};
+
+// Class that manages speech transcription and synchronisation with the
+// REAPER project via project markers.
+class STTTranscriber {
+public:
+  explicit STTTranscriber(ReaProject* project);
+
+  // Feeds an audio block to the STT engine.
+  void ProcessBlock(PCM_source_transfer_t* block);
+
+  // Adds a word marker at the specified position.
+  void AddWord(const std::string& word, double position);
+
+  // Returns a list of markers matching the target word.
+  std::vector<WordMarker> Search(const std::string& target) const;
+
+  // Replaces all occurrences of the target word with the replacement.
+  void ReplaceWord(const std::string& target, const std::string& replacement);
+
+  // Accessor for the full transcript.
+  const std::string& transcript() const { return transcript_; }
+
+private:
+  ReaProject* project_;
+  LocalSTTEngine stt_;
+  std::vector<WordMarker> markers_;
+  std::string transcript_;
+};
+
+#endif // REAPER_STT_UTILS_H
+


### PR DESCRIPTION
## Summary
- add `stt_utils` helper for feeding `PCM_source_transfer_t` blocks to a local STT engine
- support adding word markers and keeping a parallel text transcript
- provide basic search and replace utilities for word-level editing

## Testing
- `g++ -std=c++17 -I. -Isdk -Ireaper-plugins -c reaper-plugins/stt_utils.cpp` *(fails: fatal error: ../WDL/swell/swell.h: No such file or directory)*
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68966eb59f78832c9cd3cfc89ce1c9ce