### PR TITLE
Add MIDI effect interface and sample MIDI arpeggiator

### DIFF
--- a/sdk/example_midi_arp/midi_arpeggiator.cpp
+++ b/sdk/example_midi_arp/midi_arpeggiator.cpp
@@ -1,0 +1,58 @@
+#include "../reaper_plugin.h"
+#include "reaper_plugin_functions.h"
+
+class SimpleArp : public MIDI_effect
+{
+public:
+  SimpleArp() {}
+  MIDI_effect* Duplicate() override { return new SimpleArp(); }
+  bool IsAvailable() override { return true; }
+  void SetAvailable(bool) override {}
+  const char* GetType() override { return "SimpleArp"; }
+  int PropertiesWindow(HWND) override { return 0; }
+  void Process(MIDI_effect_transfer_t* block) override
+  {
+    if (!block || !block->input_events || !block->output_events) return;
+    int pos = 0;
+    MIDI_event_t* evt;
+    while ((evt = block->input_events->EnumItems(&pos)))
+    {
+      // pass through original event
+      block->output_events->AddItem(evt);
+      if (evt->is_note_on())
+      {
+        MIDI_event_t e = *evt;
+        e.midi_message[1] = evt->midi_message[1] + 4; // major third
+        e.frame_offset += 240; // simple offset
+        block->output_events->AddItem(&e);
+        e.midi_message[1] = evt->midi_message[1] + 7; // perfect fifth
+        e.frame_offset += 240;
+        block->output_events->AddItem(&e);
+      }
+    }
+  }
+  void SaveState(ProjectStateContext*) override {}
+  int LoadState(const char*, ProjectStateContext*) override { return 0; }
+  int Extended(int, void*, void*, void*) override { return 0; }
+};
+
+static const char* ArpName() { return "Example Arpeggiator"; }
+static MIDI_effect* CreateArp() { return new SimpleArp(); }
+
+static midieffect_register_t reg = { ArpName, CreateArp };
+static int (*plugin_register)(const char*, void*);
+
+extern "C" {
+REAPER_PLUGIN_DLL_EXPORT int REAPER_PLUGIN_ENTRYPOINT(REAPER_PLUGIN_HINSTANCE hInstance, reaper_plugin_info_t* rec)
+{
+  if (rec)
+  {
+    if (rec->caller_version != REAPER_PLUGIN_VERSION || !rec->Register) return 0;
+    plugin_register = rec->Register;
+    plugin_register("midieffect", &reg);
+    return 1;
+  }
+  plugin_register("-midieffect", &reg);
+  return 0;
+}
+}

--- a/sdk/reaper_plugin.h
+++ b/sdk/reaper_plugin.h
@@ -604,6 +604,43 @@ class PCM_source
     virtual int Extended(int call, void *parm1, void *parm2, void *parm3) { return 0; } // return 0 if unsupported
 };
 
+/***************************************************************************************
+**** MIDI effect API
+***************************************************************************************/
+
+typedef struct _MIDI_effect_transfer_t
+{
+  double time_s; // start time of block
+  MIDI_eventlist* input_events;  // events entering the effect
+  MIDI_eventlist* output_events; // events produced by the effect
+} MIDI_effect_transfer_t;
+
+class MIDI_effect
+{
+  public:
+    virtual ~MIDI_effect() { }
+
+    virtual MIDI_effect *Duplicate()=0;
+    virtual bool IsAvailable()=0;
+    virtual void SetAvailable(bool avail) { }
+    virtual const char *GetType()=0;
+
+    virtual int PropertiesWindow(HWND hwndParent)=0;
+
+    virtual void Process(MIDI_effect_transfer_t *block)=0;
+
+    virtual void SaveState(ProjectStateContext *ctx)=0;
+    virtual int LoadState(const char *firstline, ProjectStateContext *ctx)=0; // -1 on error
+
+    virtual int Extended(int call, void *parm1, void *parm2, void *parm3) { return 0; } // return 0 if unsupported
+};
+
+typedef struct _REAPER_midieffect_register_t // register with "midieffect"
+{
+  const char* (*GetName)();
+  MIDI_effect* (*Create)();
+} midieffect_register_t;
+
 typedef struct _REAPER_cue
 {
   int m_id; // ignored for PCM_SINK_EXT_ADDCUE, populated for PCM_SOURCE_EXT_ENUMCUES

--- a/sdk/reaper_plugin_functions.h
+++ b/sdk/reaper_plugin_functions.h
@@ -7262,6 +7262,22 @@ REAPERAPI_DEF //==============================================
   int (*REAPERAPI_FUNCNAME(TrackFX_GetNumParams))(MediaTrack* track, int fx);
 #endif
 
+#if defined(REAPERAPI_WANT_TrackMIDI_FX_AddByName) || !defined(REAPERAPI_MINIMAL)
+REAPERAPI_DEF //==============================================
+// TrackMIDI_FX_AddByName
+// Adds or queries the position of a named MIDI effect in the track MIDI FX chain, which processes events before instrument FX. Specify instantiate semantics as with TrackFX_AddByName. Returns -1 on failure or the new position in chain on success.
+
+  int (*REAPERAPI_FUNCNAME(TrackMIDI_FX_AddByName))(MediaTrack* track, const char* fxname, int instantiate);
+#endif
+
+#if defined(REAPERAPI_WANT_TrackMIDI_FX_GetNumParams) || !defined(REAPERAPI_MINIMAL)
+REAPERAPI_DEF //==============================================
+// TrackMIDI_FX_GetNumParams
+// Returns the number of parameters for the MIDI effect at index fx in the track MIDI FX chain.
+
+  int (*REAPERAPI_FUNCNAME(TrackMIDI_FX_GetNumParams))(MediaTrack* track, int fx);
+#endif
+
 #if defined(REAPERAPI_WANT_TrackFX_GetOffline) || !defined(REAPERAPI_MINIMAL)
 REAPERAPI_DEF //==============================================
 // TrackFX_GetOffline
@@ -10132,6 +10148,12 @@ REAPERAPI_DEF //==============================================
       #endif
       #if defined(REAPERAPI_WANT_TrackFX_GetNumParams) || !defined(REAPERAPI_MINIMAL)
         {(void**)&REAPERAPI_FUNCNAME(TrackFX_GetNumParams),"TrackFX_GetNumParams"},
+      #endif
+      #if defined(REAPERAPI_WANT_TrackMIDI_FX_AddByName) || !defined(REAPERAPI_MINIMAL)
+        {(void**)&REAPERAPI_FUNCNAME(TrackMIDI_FX_AddByName),"TrackMIDI_FX_AddByName"},
+      #endif
+      #if defined(REAPERAPI_WANT_TrackMIDI_FX_GetNumParams) || !defined(REAPERAPI_MINIMAL)
+        {(void**)&REAPERAPI_FUNCNAME(TrackMIDI_FX_GetNumParams),"TrackMIDI_FX_GetNumParams"},
       #endif
       #if defined(REAPERAPI_WANT_TrackFX_GetOffline) || !defined(REAPERAPI_MINIMAL)
         {(void**)&REAPERAPI_FUNCNAME(TrackFX_GetOffline),"TrackFX_GetOffline"},


### PR DESCRIPTION
## Summary
- introduce `MIDI_effect` API for pre-instrument MIDI processing and registration
- expose `TrackMIDI_FX_AddByName` and `TrackMIDI_FX_GetNumParams` through plugin functions header
- add example MIDI arpeggiator plug-in demonstrating new MIDI FX chain

## Testing
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_689670162954832cb1df19b3366764a2