### PR TITLE
Include wdltypes before plugin API

### DIFF
--- a/reaper-plugins/reaper_mp3/mp3_index.cpp
+++ b/reaper-plugins/reaper_mp3/mp3_index.cpp
@@ -12,6 +12,8 @@
 #include "../../WDL/wdlcstring.h"
 
 #include "../reaper_plugin.h"
+#include "../../WDL/wdltypes.h"
+#include "../../sdk/reaper_plugin_functions.h"
 
 
 #include "mp3dec.h"

--- a/reaper-plugins/reaper_mp3/mp3dec.cpp
+++ b/reaper-plugins/reaper_mp3/mp3dec.cpp
@@ -7,6 +7,8 @@
 #include <math.h>
 
 #include "mp3dec.h"
+#include "../../WDL/wdltypes.h"
+#include "../../sdk/reaper_plugin_functions.h"
 
 
 mp3_decoder::mp3_decoder()

--- a/reaper-plugins/reaper_mp3/pcmsink_mp3lame.cpp
+++ b/reaper-plugins/reaper_mp3/pcmsink_mp3lame.cpp
@@ -19,6 +19,8 @@ extern void (*gOnMallocFailPtr)(int);
 #include "resource.h"
 
 #include "../reaper_plugin.h"
+#include "../../WDL/wdltypes.h"
+#include "../../sdk/reaper_plugin_functions.h"
 #include "../localize.h"
 
 #include "../../WDL/win32_utf8.c"

--- a/reaper-plugins/reaper_mp3/pcmsrc_mp3dec.cpp
+++ b/reaper-plugins/reaper_mp3/pcmsrc_mp3dec.cpp
@@ -14,6 +14,8 @@ void (*gOnMallocFailPtr)(int);
 //#include "main.h"
 //#include "resource.h"
 #include "../reaper_plugin.h"
+#include "../../WDL/wdltypes.h"
+#include "../../sdk/reaper_plugin_functions.h"
 #include "../../WDL/lineparse.h"
 #include "../../WDL/wdlcstring.h"
 #include "../../WDL/wdlstring.h"

--- a/sdk/example_raw/pcmsink_raw.cpp
+++ b/sdk/example_raw/pcmsink_raw.cpp
@@ -39,6 +39,7 @@
 #include "resource.h"
 
 #include "../reaper_plugin.h"
+#include "../../WDL/wdltypes.h"
 #include "reaper_plugin_functions.h"
 
 #include "../../WDL/wdlstring.h"

--- a/sdk/example_raw/pcmsrc_raw.cpp
+++ b/sdk/example_raw/pcmsrc_raw.cpp
@@ -47,6 +47,7 @@
 #define REAPERAPI_WANT_get_ini_file
 #define REAPER_PLUGIN_FUNCTIONS_IMPL_LOADFUNC
 #include "../reaper_plugin.h"
+#include "../../WDL/wdltypes.h"
 #include "reaper_plugin_functions.h"
 
 #include "../../WDL/fileread.h"


### PR DESCRIPTION
## Summary
- ensure sample plug-ins include `wdltypes.h` before `reaper_plugin_functions.h` so WDL_INT64 and related types are defined

## Testing
- `g++ -std=c++11 -fpermissive -w -Isdk -I. -c sdk/example_raw/pcmsink_raw.cpp`【465c2f†L1-L2】
- `g++ -std=c++11 -fpermissive -w -Isdk -I. -c sdk/example_raw/pcmsrc_raw.cpp`【c00224†L1-L2】
- `g++ -std=c++11 -fpermissive -w -Ireaper-plugins -I. -Isdk -c reaper-plugins/reaper_mp3/mp3_index.cpp`【4581d0†L1-L2】
- `g++ -std=c++11 -fpermissive -w -Ireaper-plugins -I. -Isdk -c reaper-plugins/reaper_mp3/pcmsink_mp3lame.cpp`【af9dae†L1-L2】
- `g++ -std=c++11 -fpermissive -w -Ireaper-plugins -I. -Isdk -c reaper-plugins/reaper_mp3/pcmsrc_mp3dec.cpp`【388d33†L1-L2】
- `g++ -std=c++11 -fpermissive -w -Ireaper-plugins -I. -Isdk -c reaper-plugins/reaper_mp3/mp3dec.cpp`【0ee58b†L1-L2】

------
https://chatgpt.com/codex/tasks/task_e_68967886c774832c8287788520f25a0f