### PR TITLE
Add track marker API and lane controls

### DIFF
--- a/reaper-plugins/reaper_plugin.h
+++ b/reaper-plugins/reaper_plugin.h
@@ -347,6 +347,8 @@ enum
 // &0xFFFF0000 is for receiver use
 
 #ifdef __cplusplus
+#include <string>
+#include <cstdio>
 
 #ifndef _WDL_PROJECTSTATECONTEXT_DEFINED_
 #define _REAPER_PLUGIN_PROJECTSTATECONTEXT_DEFINED_
@@ -406,7 +408,7 @@ class MIDI_eventlist
 {
 public:
   virtual void AddItem(MIDI_event_t *evt)=0;
-  virtual MIDI_event_t *EnumItems(int *bpos)=0; 
+  virtual MIDI_event_t *EnumItems(int *bpos)=0;
   virtual void DeleteItem(int bpos)=0;
   virtual int GetSize()=0; // size of block in bytes
   virtual void Empty()=0;
@@ -415,6 +417,34 @@ protected:
   // this is only defined in REAPER 4.60+, for 4.591 and earlier you should delete only via the implementation pointer
   virtual ~MIDI_eventlist() { }
 };
+
+struct track_marker_t {
+  int index;      // marker/region index number
+  int lane;       // lane index
+  bool isrgn;     // true if region
+  double pos;     // start position
+  double rgnend;  // end position (ignored if !isrgn)
+  std::string name;
+};
+
+static inline void TrackStateCtx_WriteTrackMarker(ProjectStateContext* ctx, const track_marker_t& tm)
+{
+  ctx->AddLine("TM %d %d %d %.17g %.17g %s", tm.index, tm.lane, tm.isrgn ? 1 : 0,
+               tm.pos, tm.rgnend, tm.name.c_str());
+}
+
+static inline bool TrackStateCtx_ReadTrackMarker(const char* line, track_marker_t& tm)
+{
+  int isrgn = 0;
+  char namebuf[4096] = {0};
+  if (std::sscanf(line, "TM %d %d %d %lf %lf %4095[^\r\n]", &tm.index, &tm.lane, &isrgn, &tm.pos, &tm.rgnend, namebuf) >= 5)
+  {
+    tm.isrgn = isrgn != 0;
+    tm.name = namebuf;
+    return true;
+  }
+  return false;
+}
 
 #endif // __cplusplus
 
@@ -1488,6 +1518,8 @@ class IReaperControlSurface
 #define CSURF_EXT_SETFXCHANGE 0x00010013 // parm1=(MediaTrack*)track, whenever FX are added, deleted, or change order. flags=(INT_PTR)parm2, &1=rec fx
 #define CSURF_EXT_SETPROJECTMARKERCHANGE 0x00010014 // whenever project markers are changed
 #define CSURF_EXT_TRACKFX_PRESET_CHANGED  0x00010015 // parm1=(MediaTrack*)track, parm2=(int*)fxidx (6.13+ probably)
+#define CSURF_EXT_SETTRACKMARKERLANEVIS 0x00010016 // parm1=(MediaTrack*)track, parm2=(int*)lane, parm3=(int*)visible
+#define CSURF_EXT_SETTRACKMARKERLANECOLOR 0x00010017 // parm1=(MediaTrack*)track, parm2=(int*)lane, parm3=(int*)color
 #define CSURF_EXT_SUPPORTS_EXTENDED_TOUCH 0x00080001 // returns nonzero if GetTouchState can take isPan=2 for width, etc
 #define CSURF_EXT_MIDI_DEVICE_REMAP 0x00010099 // parm1 = isout, parm2 = old idx, parm3 = new idx
 

--- a/sdk/reaper_plugin_functions.h
+++ b/sdk/reaper_plugin_functions.h
@@ -155,6 +155,14 @@ REAPERAPI_DEF //==============================================
   bool (*REAPERAPI_FUNCNAME(AddTempoTimeSigMarker))(ReaProject* proj, double timepos, double bpm, int timesig_num, int timesig_denom, bool lineartempochange);
 #endif
 
+#if defined(REAPERAPI_WANT_AddTrackMarker) || !defined(REAPERAPI_MINIMAL)
+REAPERAPI_DEF //==============================================
+// AddTrackMarker
+// Returns the index of the created track marker/region, or -1 on failure. lane specifies the marker lane.
+
+  int (*REAPERAPI_FUNCNAME(AddTrackMarker))(MediaTrack* track, int lane, bool isrgn, double pos, double rgnend, const char* name, int wantidx);
+#endif
+
 #if defined(REAPERAPI_WANT_adjustZoom) || !defined(REAPERAPI_MINIMAL)
 REAPERAPI_DEF //==============================================
 // adjustZoom
@@ -1054,6 +1062,14 @@ REAPERAPI_DEF //==============================================
   void (*REAPERAPI_FUNCNAME(DeleteTrack))(MediaTrack* tr);
 #endif
 
+#if defined(REAPERAPI_WANT_DeleteTrackMarker) || !defined(REAPERAPI_MINIMAL)
+REAPERAPI_DEF //==============================================
+// DeleteTrackMarker
+// Delete a marker or region from a specific track and lane.
+
+  bool (*REAPERAPI_FUNCNAME(DeleteTrackMarker))(MediaTrack* track, int lane, int markrgnindexnumber, bool isrgn);
+#endif
+
 #if defined(REAPERAPI_WANT_DeleteTrackMediaItem) || !defined(REAPERAPI_MINIMAL)
 REAPERAPI_DEF //==============================================
 // DeleteTrackMediaItem
@@ -1275,6 +1291,14 @@ REAPERAPI_DEF //==============================================
 // returns false if there are no plugins on the track that support MIDI programs,or if all programs have been enumerated
 
   bool (*REAPERAPI_FUNCNAME(EnumTrackMIDIProgramNamesEx))(ReaProject* proj, MediaTrack* track, int programNumber, char* programName, int programName_sz);
+#endif
+
+#if defined(REAPERAPI_WANT_EnumTrackMarkers) || !defined(REAPERAPI_MINIMAL)
+REAPERAPI_DEF //==============================================
+// EnumTrackMarkers
+// Enumerate markers and regions on a track. Returns 0 when no more markers are available.
+
+  int (*REAPERAPI_FUNCNAME(EnumTrackMarkers))(MediaTrack* track, int idx, int* laneOut, bool* isrgnOut, double* posOut, double* rgnendOut, const char** nameOut, int* markrgnindexnumberOut);
 #endif
 
 #if defined(REAPERAPI_WANT_Envelope_Evaluate) || !defined(REAPERAPI_MINIMAL)
@@ -3509,6 +3533,14 @@ REAPERAPI_DEF //==============================================
 // Returns "MASTER" for master track, "Track N" if track has no name.
 
   bool (*REAPERAPI_FUNCNAME(GetTrackName))(MediaTrack* track, char* bufOut, int bufOut_sz);
+#endif
+
+#if defined(REAPERAPI_WANT_GetTrackMarkerLaneInfo) || !defined(REAPERAPI_MINIMAL)
+REAPERAPI_DEF //==============================================
+// GetTrackMarkerLaneInfo
+// Retrieve visibility and color information for a track marker lane. color is ColorToNative(r,g,b)|0x1000000 or 0 for default.
+
+  bool (*REAPERAPI_FUNCNAME(GetTrackMarkerLaneInfo))(MediaTrack* track, int lane, bool* visibleOut, int* colorOut);
 #endif
 
 #if defined(REAPERAPI_WANT_GetTrackNumMediaItems) || !defined(REAPERAPI_MINIMAL)
@@ -6218,6 +6250,14 @@ REAPERAPI_DEF //==============================================
   void (*REAPERAPI_FUNCNAME(SetTrackColor))(MediaTrack* track, int color);
 #endif
 
+#if defined(REAPERAPI_WANT_SetTrackMarkerLaneInfo) || !defined(REAPERAPI_MINIMAL)
+REAPERAPI_DEF //==============================================
+// SetTrackMarkerLaneInfo
+// Update visibility and color for a track marker lane. color is ColorToNative(r,g,b)|0x1000000 or 0 for default.
+
+  bool (*REAPERAPI_FUNCNAME(SetTrackMarkerLaneInfo))(MediaTrack* track, int lane, bool visible, int color);
+#endif
+
 #if defined(REAPERAPI_WANT_SetTrackMIDILyrics) || !defined(REAPERAPI_MINIMAL)
 REAPERAPI_DEF //==============================================
 // SetTrackMIDILyrics
@@ -7748,6 +7788,9 @@ REAPERAPI_DEF //==============================================
       #if defined(REAPERAPI_WANT_AddTempoTimeSigMarker) || !defined(REAPERAPI_MINIMAL)
         {(void**)&REAPERAPI_FUNCNAME(AddTempoTimeSigMarker),"AddTempoTimeSigMarker"},
       #endif
+      #if defined(REAPERAPI_WANT_AddTrackMarker) || !defined(REAPERAPI_MINIMAL)
+        {(void**)&REAPERAPI_FUNCNAME(AddTrackMarker),"AddTrackMarker"},
+      #endif
       #if defined(REAPERAPI_WANT_adjustZoom) || !defined(REAPERAPI_MINIMAL)
         {(void**)&REAPERAPI_FUNCNAME(adjustZoom),"adjustZoom"},
       #endif
@@ -8096,6 +8139,9 @@ REAPERAPI_DEF //==============================================
       #if defined(REAPERAPI_WANT_DeleteTrack) || !defined(REAPERAPI_MINIMAL)
         {(void**)&REAPERAPI_FUNCNAME(DeleteTrack),"DeleteTrack"},
       #endif
+      #if defined(REAPERAPI_WANT_DeleteTrackMarker) || !defined(REAPERAPI_MINIMAL)
+        {(void**)&REAPERAPI_FUNCNAME(DeleteTrackMarker),"DeleteTrackMarker"},
+      #endif
       #if defined(REAPERAPI_WANT_DeleteTrackMediaItem) || !defined(REAPERAPI_MINIMAL)
         {(void**)&REAPERAPI_FUNCNAME(DeleteTrackMediaItem),"DeleteTrackMediaItem"},
       #endif
@@ -8182,6 +8228,9 @@ REAPERAPI_DEF //==============================================
       #endif
       #if defined(REAPERAPI_WANT_EnumTrackMIDIProgramNamesEx) || !defined(REAPERAPI_MINIMAL)
         {(void**)&REAPERAPI_FUNCNAME(EnumTrackMIDIProgramNamesEx),"EnumTrackMIDIProgramNamesEx"},
+      #endif
+      #if defined(REAPERAPI_WANT_EnumTrackMarkers) || !defined(REAPERAPI_MINIMAL)
+        {(void**)&REAPERAPI_FUNCNAME(EnumTrackMarkers),"EnumTrackMarkers"},
       #endif
       #if defined(REAPERAPI_WANT_Envelope_Evaluate) || !defined(REAPERAPI_MINIMAL)
         {(void**)&REAPERAPI_FUNCNAME(Envelope_Evaluate),"Envelope_Evaluate"},
@@ -8812,6 +8861,9 @@ REAPERAPI_DEF //==============================================
       #endif
       #if defined(REAPERAPI_WANT_GetTrackName) || !defined(REAPERAPI_MINIMAL)
         {(void**)&REAPERAPI_FUNCNAME(GetTrackName),"GetTrackName"},
+      #endif
+      #if defined(REAPERAPI_WANT_GetTrackMarkerLaneInfo) || !defined(REAPERAPI_MINIMAL)
+        {(void**)&REAPERAPI_FUNCNAME(GetTrackMarkerLaneInfo),"GetTrackMarkerLaneInfo"},
       #endif
       #if defined(REAPERAPI_WANT_GetTrackNumMediaItems) || !defined(REAPERAPI_MINIMAL)
         {(void**)&REAPERAPI_FUNCNAME(GetTrackNumMediaItems),"GetTrackNumMediaItems"},
@@ -9769,6 +9821,9 @@ REAPERAPI_DEF //==============================================
       #endif
       #if defined(REAPERAPI_WANT_SetTrackColor) || !defined(REAPERAPI_MINIMAL)
         {(void**)&REAPERAPI_FUNCNAME(SetTrackColor),"SetTrackColor"},
+      #endif
+      #if defined(REAPERAPI_WANT_SetTrackMarkerLaneInfo) || !defined(REAPERAPI_MINIMAL)
+        {(void**)&REAPERAPI_FUNCNAME(SetTrackMarkerLaneInfo),"SetTrackMarkerLaneInfo"},
       #endif
       #if defined(REAPERAPI_WANT_SetTrackMIDILyrics) || !defined(REAPERAPI_MINIMAL)
         {(void**)&REAPERAPI_FUNCNAME(SetTrackMIDILyrics),"SetTrackMIDILyrics"},


### PR DESCRIPTION
## Summary
- add AddTrackMarker/EnumTrackMarkers/DeleteTrackMarker API entries
- support lane visibility and color via Get/SetTrackMarkerLaneInfo
- include track marker state helpers and control-surface hook codes

## Testing
- `g++ -std=c++17 -c /tmp/check.cpp -I.` *(fails: fatal error: ../WDL/swell/swell.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689671339e94832ca43593af8ddd6314