### PR TITLE
Add MusicXML export/import example and API declarations

### DIFF
--- a/sdk/example_musicxml/README.md
+++ b/sdk/example_musicxml/README.md
@@ -1,0 +1,27 @@
+# MusicXML Round-trip Example
+
+This example plug-in shows how to export MIDI data from a REAPER track to a
+MusicXML file and import a MusicXML file back into a track.
+
+## Building
+
+Ensure the WDL submodule is checked out next to the `sdk` directory:
+
+```bash
+git submodule update --init --recursive
+```
+
+Then compile `musicxml_util.cpp` as a REAPER extension and copy the resulting
+plug-in to your REAPER extensions directory.
+
+## Usage
+
+1. Load the plug-in into REAPER.
+2. Select a track that contains MIDI items.
+3. Call the `ExportTrackMIDIToMusicXML` API function to create `output.musicxml`.
+4. Open the file in notation software such as Sibelius and make edits.
+5. Export the changes as MusicXML from the notation software.
+6. Call `ImportTrackMIDIFromMusicXML` to read the edited file back onto the track.
+
+The accompanying `sample_project.rpp` and `sample.musicxml` demonstrate a
+simple round-trip workflow.

--- a/sdk/example_musicxml/musicxml_util.cpp
+++ b/sdk/example_musicxml/musicxml_util.cpp
@@ -1,0 +1,133 @@
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+#include "../../WDL/wdltypes.h"
+#include "../reaper_plugin.h"
+#include "../reaper_plugin_functions.h"
+
+// Export selected track MIDI to MusicXML
+static bool DoExportTrackMIDIToMusicXML(MediaTrack* tr, const char* fn)
+{
+    if (!tr || !fn) return false;
+    FILE* f = std::fopen(fn, "w");
+    if (!f) return false;
+
+    std::fprintf(f, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+    std::fprintf(f, "<score-partwise version=\"3.1\">\n");
+    std::fprintf(f, "  <part-list><score-part id=\"P1\"><part-name>Track</part-name></score-part></part-list>\n");
+    std::fprintf(f, "  <part id=\"P1\">\n");
+    std::fprintf(f, "    <measure number=\"1\">\n");
+
+    const int itemCount = CountTrackMediaItems(tr);
+    for (int i = 0; i < itemCount; ++i)
+    {
+        MediaItem* item = GetTrackMediaItem(tr, i);
+        const int takeCount = GetMediaItemNumTakes(item);
+        for (int t = 0; t < takeCount; ++t)
+        {
+            MediaItem_Take* take = GetMediaItemTake(item, t);
+            if (!take || !TakeIsMIDI(take)) continue;
+
+            int buf_sz = 0;
+            MIDI_GetAllEvts(take, NULL, &buf_sz);
+            char* buf = (char*)std::malloc(buf_sz);
+            if (buf && MIDI_GetAllEvts(take, buf, &buf_sz))
+            {
+                int pos = 0;
+                int ppq = 0;
+                while (pos < buf_sz)
+                {
+                    int offset = *(int*)(buf + pos); pos += 4;
+                    unsigned char flags = (unsigned char)buf[pos++]; (void)flags;
+                    unsigned char msglen = (unsigned char)buf[pos++];
+                    unsigned char* msg = (unsigned char*)buf + pos;
+                    pos += msglen;
+                    ppq += offset;
+                    if (msglen >= 3 && (msg[0] & 0xF0) == 0x90 && msg[2] > 0)
+                    {
+                        int pitch = msg[1];
+                        static const char* steps[12] = {"C","C#","D","D#","E","F","F#","G","G#","A","A#","B"};
+                        const char* step = steps[pitch % 12];
+                        int octave = pitch / 12 - 1;
+                        std::fprintf(f, "      <note>\n");
+                        std::fprintf(f, "        <pitch><step>%c</step", step[0]);
+                        if (step[1] == '#') std::fprintf(f, "<alter>1</alter>");
+                        std::fprintf(f, "<octave>%d</octave></pitch>\n", octave);
+                        std::fprintf(f, "        <duration>1</duration>\n");
+                        std::fprintf(f, "      </note>\n");
+                    }
+                }
+                std::free(buf);
+            }
+        }
+    }
+
+    std::fprintf(f, "    </measure>\n");
+    std::fprintf(f, "  </part>\n");
+    std::fprintf(f, "</score-partwise>\n");
+    std::fclose(f);
+    return true;
+}
+
+// Import simple MusicXML to selected track
+static bool DoImportTrackMIDIFromMusicXML(MediaTrack* tr, const char* fn)
+{
+    if (!tr || !fn) return false;
+    FILE* f = std::fopen(fn, "r");
+    if (!f) return false;
+
+    MediaItem* item = AddMediaItemToTrack(tr);
+    MediaItem_Take* take = AddTakeToMediaItem(item);
+    double ppq = 0.0;
+    char line[1024];
+    char step = 'C';
+    int alter = 0;
+    int octave = 4;
+    bool inNote = false;
+    while (std::fgets(line, sizeof(line), f))
+    {
+        if (std::strstr(line, "<note")) { inNote = true; step = 'C'; alter = 0; octave = 4; }
+        if (inNote)
+        {
+            char* p;
+            if ((p = std::strstr(line, "<step>"))) step = p[6];
+            if ((p = std::strstr(line, "<alter>"))) alter = std::atoi(p + 7);
+            if ((p = std::strstr(line, "<octave>"))) octave = std::atoi(p + 8);
+            if (std::strstr(line, "</note>"))
+            {
+                int base;
+                switch (step)
+                {
+                    case 'C': base = 0; break; case 'D': base = 2; break;
+                    case 'E': base = 4; break; case 'F': base = 5; break;
+                    case 'G': base = 7; break; case 'A': base = 9; break;
+                    case 'B': base = 11; break; default: base = 0; break;
+                }
+                base += alter;
+                int pitch = (octave + 1) * 12 + base;
+                double start = ppq;
+                double end = ppq + 960.0;
+                MIDI_InsertNote(take, false, false, start, end, 0, pitch, 100, NULL);
+                ppq += 960.0;
+                inNote = false;
+            }
+        }
+    }
+    std::fclose(f);
+    return true;
+}
+
+extern "C" {
+REAPER_PLUGIN_DLL_EXPORT int REAPER_PLUGIN_ENTRYPOINT(REAPER_PLUGIN_HINSTANCE hInstance, reaper_plugin_info_t* rec)
+{
+    (void)hInstance;
+    if (!rec) return 0;
+    if (rec->caller_version != REAPER_PLUGIN_VERSION || !rec->GetFunc) return 0;
+    if (REAPERAPI_LoadAPI(rec->GetFunc)) return 0;
+    rec->Register("API_ExportTrackMIDIToMusicXML", (void*)DoExportTrackMIDIToMusicXML);
+    rec->Register("API_ImportTrackMIDIFromMusicXML", (void*)DoImportTrackMIDIFromMusicXML);
+    return 1;
+}
+}
+

--- a/sdk/example_musicxml/sample.musicxml
+++ b/sdk/example_musicxml/sample.musicxml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1">
+      <part-name>Sample</part-name>
+    </score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>1</duration>
+        <type>quarter</type>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/sdk/example_musicxml/sample_project.rpp
+++ b/sdk/example_musicxml/sample_project.rpp
@@ -1,0 +1,20 @@
+<REAPER_PROJECT 0.1 "7.0" 0
+  <TRACK
+    NAME "MIDI Track"
+    <ITEM
+      POSITION 0
+      LENGTH 1
+      <TAKE
+        NAME "Take"
+        SOURCE MIDI
+        <SOURCE MIDI
+          <EVENTS
+            E 0 90 3C 64
+            E 480 80 3C 00
+            E 0
+          >
+        >
+      >
+    >
+  >
+>

--- a/sdk/reaper_plugin_functions.h
+++ b/sdk/reaper_plugin_functions.h
@@ -1333,6 +1333,22 @@ REAPERAPI_DEF //==============================================
   const char* (*REAPERAPI_FUNCNAME(ExecProcess))(const char* cmdline, int timeoutmsec);
 #endif
 
+#if defined(REAPERAPI_WANT_ExportTrackMIDIToMusicXML) || !defined(REAPERAPI_MINIMAL)
+REAPERAPI_DEF //==============================================
+// ExportTrackMIDIToMusicXML
+// Export track MIDI data to a MusicXML file.
+
+  bool (*REAPERAPI_FUNCNAME(ExportTrackMIDIToMusicXML))(MediaTrack* tr, const char* fn);
+#endif
+
+#if defined(REAPERAPI_WANT_ImportTrackMIDIFromMusicXML) || !defined(REAPERAPI_MINIMAL)
+REAPERAPI_DEF //==============================================
+// ImportTrackMIDIFromMusicXML
+// Import MIDI data from a MusicXML file into a track.
+
+  bool (*REAPERAPI_FUNCNAME(ImportTrackMIDIFromMusicXML))(MediaTrack* tr, const char* fn);
+#endif
+
 #if defined(REAPERAPI_WANT_file_exists) || !defined(REAPERAPI_MINIMAL)
 REAPERAPI_DEF //==============================================
 // file_exists
@@ -8203,6 +8219,12 @@ REAPERAPI_DEF //==============================================
       #endif
       #if defined(REAPERAPI_WANT_ExecProcess) || !defined(REAPERAPI_MINIMAL)
         {(void**)&REAPERAPI_FUNCNAME(ExecProcess),"ExecProcess"},
+      #endif
+      #if defined(REAPERAPI_WANT_ExportTrackMIDIToMusicXML) || !defined(REAPERAPI_MINIMAL)
+        {(void**)&REAPERAPI_FUNCNAME(ExportTrackMIDIToMusicXML),"ExportTrackMIDIToMusicXML"},
+      #endif
+      #if defined(REAPERAPI_WANT_ImportTrackMIDIFromMusicXML) || !defined(REAPERAPI_MINIMAL)
+        {(void**)&REAPERAPI_FUNCNAME(ImportTrackMIDIFromMusicXML),"ImportTrackMIDIFromMusicXML"},
       #endif
       #if defined(REAPERAPI_WANT_file_exists) || !defined(REAPERAPI_MINIMAL)
         {(void**)&REAPERAPI_FUNCNAME(file_exists),"file_exists"},


### PR DESCRIPTION
## Summary
- expose `ExportTrackMIDIToMusicXML` and `ImportTrackMIDIFromMusicXML` in the REAPER API header
- add example plug-in implementing MusicXML export/import using `MIDI_GetAllEvts`
- include sample project files for round-trip testing with notation software
- document WDL submodule requirement and fix example build by including WDL headers and avoiding API name collisions

## Testing
- `g++ -std=c++17 -c sdk/example_musicxml/musicxml_util.cpp -o /tmp/musicxml.o`

------
https://chatgpt.com/codex/tasks/task_e_689671459d00832cbb44ea60432a0b54