### PR TITLE
Expose MIDI live mode API

### DIFF
--- a/sdk/reaper_plugin_functions.h
+++ b/sdk/reaper_plugin_functions.h
@@ -2247,6 +2247,14 @@ REAPERAPI_DEF //==============================================
   bool (*REAPERAPI_FUNCNAME(GetMIDIOutputName))(int dev, char* nameout, int nameout_sz);
 #endif
 
+#if defined(REAPERAPI_WANT_GetMIDI_LiveMode) || !defined(REAPERAPI_MINIMAL)
+REAPERAPI_DEF //==============================================
+// GetMIDI_LiveMode
+// Query whether minimal-buffering live mode is enabled for MIDI tracks in the project.
+
+  bool (*REAPERAPI_FUNCNAME(GetMIDI_LiveMode))(ReaProject* proj);
+#endif
+
 #if defined(REAPERAPI_WANT_GetMixerScroll) || !defined(REAPERAPI_MINIMAL)
 REAPERAPI_DEF //==============================================
 // GetMixerScroll
@@ -2984,7 +2992,8 @@ REAPERAPI_DEF //==============================================
 // RENDER_DELAY: seconds to delay start of render to allow FX to initialize and load samples (requires RENDER_SETTINGS&(16<<16))
 // PROJECT_SRATE : sample rate (ignored unless PROJECT_SRATE_USE set)
 // PROJECT_SRATE_USE : set to 1 if project sample rate is used
-// 
+// MIDI_LIVE_MODE : 1 to stream MIDI instrument tracks directly to outputs with minimal buffering, 0 otherwise (serialized in project files)
+//
 
   double (*REAPERAPI_FUNCNAME(GetSetProjectInfo))(ReaProject* project, const char* desc, double value, bool is_set);
 #endif
@@ -6036,6 +6045,14 @@ REAPERAPI_DEF //==============================================
   void (*REAPERAPI_FUNCNAME(SetMIDIEditorGrid))(ReaProject* project, double division);
 #endif
 
+#if defined(REAPERAPI_WANT_SetMIDI_LiveMode) || !defined(REAPERAPI_MINIMAL)
+REAPERAPI_DEF //==============================================
+// SetMIDI_LiveMode
+// Enable or disable minimal-buffering live mode for MIDI instrument tracks in the project.
+
+  void (*REAPERAPI_FUNCNAME(SetMIDI_LiveMode))(ReaProject* proj, bool enable);
+#endif
+
 #if defined(REAPERAPI_WANT_SetMixerScroll) || !defined(REAPERAPI_MINIMAL)
 REAPERAPI_DEF //==============================================
 // SetMixerScroll
@@ -8477,6 +8494,9 @@ REAPERAPI_DEF //==============================================
       #if defined(REAPERAPI_WANT_GetMIDIOutputName) || !defined(REAPERAPI_MINIMAL)
         {(void**)&REAPERAPI_FUNCNAME(GetMIDIOutputName),"GetMIDIOutputName"},
       #endif
+      #if defined(REAPERAPI_WANT_GetMIDI_LiveMode) || !defined(REAPERAPI_MINIMAL)
+        {(void**)&REAPERAPI_FUNCNAME(GetMIDI_LiveMode),"GetMIDI_LiveMode"},
+      #endif
       #if defined(REAPERAPI_WANT_GetMixerScroll) || !defined(REAPERAPI_MINIMAL)
         {(void**)&REAPERAPI_FUNCNAME(GetMixerScroll),"GetMixerScroll"},
       #endif
@@ -9706,6 +9726,9 @@ REAPERAPI_DEF //==============================================
       #endif
       #if defined(REAPERAPI_WANT_SetMIDIEditorGrid) || !defined(REAPERAPI_MINIMAL)
         {(void**)&REAPERAPI_FUNCNAME(SetMIDIEditorGrid),"SetMIDIEditorGrid"},
+      #endif
+      #if defined(REAPERAPI_WANT_SetMIDI_LiveMode) || !defined(REAPERAPI_MINIMAL)
+        {(void**)&REAPERAPI_FUNCNAME(SetMIDI_LiveMode),"SetMIDI_LiveMode"},
       #endif
       #if defined(REAPERAPI_WANT_SetMixerScroll) || !defined(REAPERAPI_MINIMAL)
         {(void**)&REAPERAPI_FUNCNAME(SetMixerScroll),"SetMixerScroll"},


### PR DESCRIPTION
## Summary
- document new MIDI_LIVE_MODE project flag and serialization details
- add GetMIDI_LiveMode/SetMIDI_LiveMode helpers to plugin API

## Testing
- `g++ -fpermissive -DWDL_NO_DEFINE_MINMAX -include WDL/wdltypes.h -I sdk -c sdk/example_raw/pcmsink_raw.cpp`


------
https://chatgpt.com/codex/tasks/task_e_689671401520832c9ed90deb2655c9e1