### PR TITLE
feat: add ARA2 embedding hooks and callbacks

### DIFF
--- a/docs/ara2-attachment.md
+++ b/docs/ara2-attachment.md
@@ -1,0 +1,8 @@
+# Attaching ARA2 Processors to Media Items
+
+Extensions can manage ARA2 processors on media items using two callbacks:
+
+- `ARA_AttachProcessorToMediaItem(MediaItem* item, const char* processorId, const char* stateData)` associates an ARA2 processor identified by `processorId` with `item`. The optional `stateData` parameter lets extensions pass serialized processor state to the host.
+- `ARA_DetachProcessorFromMediaItem(MediaItem* item)` removes any previously attached ARA2 processor from `item`.
+
+These callbacks allow extensions to directly attach or detach ARA2 processing contexts to individual media items.

--- a/sdk/reaper_plugin_functions.h
+++ b/sdk/reaper_plugin_functions.h
@@ -205,6 +205,23 @@ REAPERAPI_DEF //==============================================
   void (*REAPERAPI_FUNCNAME(APITest))();
 #endif
 
+#if defined(REAPERAPI_WANT_ARA_AttachProcessorToMediaItem) || !defined(REAPERAPI_MINIMAL)
+REAPERAPI_DEF //==============================================
+// ARA_AttachProcessorToMediaItem
+// Attach an ARA2 processor identified by processorId to the specified media item.
+// Optional stateData contains serialized processor state or NULL.
+
+  bool (*REAPERAPI_FUNCNAME(ARA_AttachProcessorToMediaItem))(MediaItem* item, const char* processorId, const char* stateData);
+#endif
+
+#if defined(REAPERAPI_WANT_ARA_DetachProcessorFromMediaItem) || !defined(REAPERAPI_MINIMAL)
+REAPERAPI_DEF //==============================================
+// ARA_DetachProcessorFromMediaItem
+// Detach any previously attached ARA2 processor from the media item.
+
+  bool (*REAPERAPI_FUNCNAME(ARA_DetachProcessorFromMediaItem))(MediaItem* item);
+#endif
+
 #if defined(REAPERAPI_WANT_ApplyNudge) || !defined(REAPERAPI_MINIMAL)
 REAPERAPI_DEF //==============================================
 // ApplyNudge
@@ -7762,6 +7779,12 @@ REAPERAPI_DEF //==============================================
       #endif
       #if defined(REAPERAPI_WANT_APITest) || !defined(REAPERAPI_MINIMAL)
         {(void**)&REAPERAPI_FUNCNAME(APITest),"APITest"},
+      #endif
+      #if defined(REAPERAPI_WANT_ARA_AttachProcessorToMediaItem) || !defined(REAPERAPI_MINIMAL)
+        {(void**)&REAPERAPI_FUNCNAME(ARA_AttachProcessorToMediaItem),"ARA_AttachProcessorToMediaItem"},
+      #endif
+      #if defined(REAPERAPI_WANT_ARA_DetachProcessorFromMediaItem) || !defined(REAPERAPI_MINIMAL)
+        {(void**)&REAPERAPI_FUNCNAME(ARA_DetachProcessorFromMediaItem),"ARA_DetachProcessorFromMediaItem"},
       #endif
       #if defined(REAPERAPI_WANT_ApplyNudge) || !defined(REAPERAPI_MINIMAL)
         {(void**)&REAPERAPI_FUNCNAME(ApplyNudge),"ApplyNudge"},

--- a/sdk/reaper_plugin_fx_embed.h
+++ b/sdk/reaper_plugin_fx_embed.h
@@ -8,6 +8,8 @@
  *
  * to support via VST3: IEditController should support IReaperUIEmbedInterface, see reaper_vst3_interfaces.h
  *
+ * to support via ARA2: the plug-in's ARA factory should expose IReaperARAEmbedInterface (defined below)
+ *
  * to support via LV2: todo
  */
 
@@ -138,6 +140,19 @@ public:
   virtual void *getDC() { return 0; } // do not use
 
   virtual INT_PTR Extended(int id, void* data) { return 0; }
+};
+#endif
+
+#ifdef __cplusplus
+// ARA2 embedding interface. ARA-capable plug-ins can query the host for this
+// interface and send/receive REAPER_FXEMBED_WM_* messages just like VST3
+// plug-ins do via IReaperUIEmbedInterface.
+class IReaperARAEmbedInterface
+{
+public:
+  virtual INT_PTR embed_message(int msg, INT_PTR parm2, INT_PTR parm3) = 0;
+  // returns host-specific ARA context (for example an ARA::DocumentController*)
+  virtual void* get_ara_host() = 0;
 };
 #endif
 


### PR DESCRIPTION
## Summary
- add ARA2 embedding interface for fx-embed capable plug-ins
- expose callbacks for attaching and detaching ARA processors to items
- document attaching ARA2 processors to media items

## Testing
- `make test` *(fails: No rule to make target 'test')*


------
https://chatgpt.com/codex/tasks/task_e_68966de7ef60832c8dc151017f5adf5f