### PR TITLE
Guard win32 UTF-8 shim for portability

### DIFF
--- a/reaper-plugins/reaper_csurf/csurf_main.cpp
+++ b/reaper-plugins/reaper_csurf/csurf_main.cpp
@@ -10,7 +10,11 @@
 #include "../localize-import.h"
 #include "csurf.h"
 #include "osc.h"
+#ifdef _WIN32
 #include "../../WDL/win32_utf8.c"
+#else
+#include "../../WDL/wdlutf8.h"
+#endif
 
 #include "../../WDL/setthreadname.h"
 

--- a/reaper-plugins/reaper_mp3/mp3_index.cpp
+++ b/reaper-plugins/reaper_mp3/mp3_index.cpp
@@ -18,9 +18,13 @@
 
 #include "mp3dec.h"
 
+#ifdef _WIN32
 #define WDL_WIN32_UTF8_NO_UI_IMPL
 #define WDL_WIN32_UTF8_IMPL static
 #include "../../WDL/win32_utf8.c"
+#else
+#include "../../WDL/wdlutf8.h"
+#endif
 #include "../../WDL/wdlstring.h"
 #include "../../WDL/ptrlist.h"
 #include "../../WDL/mutex.h"

--- a/reaper-plugins/reaper_mp3/pcmsink_mp3lame.cpp
+++ b/reaper-plugins/reaper_mp3/pcmsink_mp3lame.cpp
@@ -23,7 +23,11 @@ extern void (*gOnMallocFailPtr)(int);
 #include "../../sdk/reaper_plugin_functions.h"
 #include "../localize.h"
 
+#ifdef _WIN32
 #include "../../WDL/win32_utf8.c"
+#else
+#include "../../WDL/wdlutf8.h"
+#endif
 
 #include "../../WDL/lineparse.h"
 #include "../../WDL/wdlstring.h"

--- a/reaper-plugins/reaper_mp3/pcmsrc_mp3dec.cpp
+++ b/reaper-plugins/reaper_mp3/pcmsrc_mp3dec.cpp
@@ -26,9 +26,13 @@ void (*gOnMallocFailPtr)(int);
 #include "../../WDL/fileread.h"
 
 
+#ifdef _WIN32
 #define WDL_WIN32_UTF8_NO_UI_IMPL
 #define WDL_WIN32_UTF8_IMPL static
 #include "../../WDL/win32_utf8.c"
+#else
+#include "../../WDL/wdlutf8.h"
+#endif
 
 
 REAPER_PLUGIN_HINSTANCE g_hInst;


### PR DESCRIPTION
## Summary
- Wrap `win32_utf8.c` include with `_WIN32` guard
- Use portable `wdlutf8.h` on non-Windows platforms in control surface and MP3 plugin sources

## Testing
- `g++ -std=c++17 -c reaper-plugins/reaper_mp3/pcmsrc_mp3dec.cpp` (fails: res.rc_mac_dlg missing)
- `g++ -std=c++17 -D__APPLE__ -c reaper-plugins/reaper_mp3/pcmsrc_mp3dec.cpp` (fails: AvailabilityMacros.h missing)


------
https://chatgpt.com/codex/tasks/task_e_68969001ccfc832cb1ea83cf033b2d73