### PR TITLE
Add macOS resource generation step

### DIFF
--- a/README
+++ b/README
@@ -77,7 +77,17 @@ The resulting `reaper_csurf.dll` will be in the current directory.
    export WDL_PATH="$REAPER_SDK/WDL"
    ```
 
-3. Build the sample plug-in:
+3. Generate macOS resource files (required for plug-ins that include
+   `res.rc_mac_*`):
+
+   ```sh
+   ./scripts/gen_mac_resources.sh
+   ```
+   This script runs `WDL/swell/swell_dlggen` and `WDL/swell/swell_menu`
+   to create the `res.rc_mac_dlg` and `res.rc_mac_menu` files in each
+   plug-in directory.
+
+4. Build the sample plug-in:
 
    ```sh
    clang++ -dynamiclib -std=c++11 -I"$REAPER_SDK/sdk" -I"$WDL_PATH" \

--- a/scripts/gen_mac_resources.sh
+++ b/scripts/gen_mac_resources.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Generate macOS resource files (res.rc_mac_dlg and res.rc_mac_menu)
+# for each plug-in with a res.rc file. This uses the WDL/swell tools.
+
+# Resolve repository root and WDL path
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+WDL_DIR="${WDL_PATH:-$REPO_ROOT/WDL}"
+
+# WDL repo contains an inner WDL directory with sources
+SWELL_DIR="$WDL_DIR/WDL/swell"
+
+DLGGEN="$SWELL_DIR/swell_dlggen"
+MENU="$SWELL_DIR/swell_menu"
+RESGEN="$SWELL_DIR/swell_resgen.sh"
+
+for rc in "$REPO_ROOT"/reaper-plugins/*/res.rc; do
+  [ -e "$rc" ] || continue
+  plugindir=$(dirname "$rc")
+  if [[ -x "$DLGGEN" && -x "$MENU" ]]; then
+    "$DLGGEN" "$rc" "$plugindir/res.rc_mac_dlg"
+    "$MENU" "$rc" "$plugindir/res.rc_mac_menu"
+  elif [[ -x "$RESGEN" ]]; then
+    "$RESGEN" "$rc"
+  else
+    echo "swell tools not found in $SWELL_DIR" >&2
+    exit 1
+  fi
+done


### PR DESCRIPTION
## Summary
- add script to generate `res.rc_mac_*` files via WDL/swell utilities
- document resource generation step in macOS build instructions

## Testing
- `scripts/gen_mac_resources.sh`


------
https://chatgpt.com/codex/tasks/task_e_689691bfb90c832c8076938cca346ba0