### PR TITLE
Refactor INI handling and improve cross-platform build

### DIFF
--- a/README
+++ b/README
@@ -92,12 +92,21 @@ The resulting `reaper_csurf.dll` will be in the current directory.
    export WDL_PATH="$REAPER_SDK/WDL"
    ```
 
-3. Build the sample plug-in:
+3. Generate the SWELL resources (required when a plug-in has a
+   `res.rc` file):
 
    ```sh
-   clang++ -dynamiclib -std=c++11 -I"$REAPER_SDK/sdk" -I"$WDL_PATH" \
+   $WDL_PATH/WDL/swell/swell_resgen.sh reaper-plugins/reaper_csurf/res.rc
+   ```
+
+4. Build a universal plug-in and link the required frameworks:
+
+   ```sh
+   clang++ -dynamiclib -std=c++11 -arch x86_64 -arch arm64 \
+     -I"$REAPER_SDK/sdk" -I"$WDL_PATH/WDL" \
      reaper-plugins/reaper_csurf/csurf_main.cpp \
      reaper-plugins/reaper_csurf/*.cpp \
+     -framework Cocoa -framework CoreAudio -framework CoreMIDI \
      -o reaper_csurf.dylib
    ```
 

--- a/cmake/ReaperPlugin.cmake
+++ b/cmake/ReaperPlugin.cmake
@@ -1,0 +1,44 @@
+function(add_reaper_plugin TARGET)
+  cmake_parse_arguments(RP "" "" "SOURCES" ${ARGN})
+  add_library(${TARGET} MODULE ${RP_SOURCES})
+
+  if(WIN32)
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/res.rc")
+      target_sources(${TARGET} PRIVATE res.rc)
+    endif()
+    set_target_properties(${TARGET} PROPERTIES SUFFIX ".dll")
+  elseif(APPLE)
+    set_target_properties(${TARGET} PROPERTIES SUFFIX ".dylib")
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/res.rc")
+      set(RC_MAC_SRC  ${CMAKE_CURRENT_BINARY_DIR}/res.rc)
+      set(RC_MAC_DLG  ${RC_MAC_SRC}_mac_dlg)
+      set(RC_MAC_MENU ${RC_MAC_SRC}_mac_menu)
+      add_custom_command(
+        OUTPUT ${RC_MAC_DLG} ${RC_MAC_MENU}
+        COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/res.rc ${RC_MAC_SRC}
+        COMMAND ${PROJECT_SOURCE_DIR}/WDL/WDL/swell/swell_resgen.sh ${RC_MAC_SRC}
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/res.rc
+        COMMENT "Generating SWELL resources"
+      )
+      target_sources(${TARGET} PRIVATE ${RC_MAC_DLG} ${RC_MAC_MENU})
+      set_source_files_properties(${RC_MAC_DLG} ${RC_MAC_MENU} PROPERTIES HEADER_FILE_ONLY TRUE)
+    endif()
+    target_link_libraries(${TARGET} "-framework Cocoa" "-framework CoreAudio" "-framework CoreMIDI")
+  else()
+    set_target_properties(${TARGET} PROPERTIES SUFFIX ".so")
+  endif()
+
+  set(REAPER_SDK_ROOT ${PROJECT_SOURCE_DIR})
+  set(REAPER_PLUGINS_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/..)
+
+  target_include_directories(${TARGET} PRIVATE
+    ${REAPER_PLUGINS_ROOT}
+    ${REAPER_SDK_ROOT}/sdk
+    ${REAPER_SDK_ROOT}/WDL/WDL
+    ${REAPER_SDK_ROOT}/WDL/swell
+    ${CMAKE_CURRENT_BINARY_DIR}
+  )
+
+  target_compile_features(${TARGET} PRIVATE cxx_std_17)
+  target_compile_definitions(${TARGET} PRIVATE NOMINMAX)
+endfunction()

--- a/reaper-plugins/reaper_atmos/CMakeLists.txt
+++ b/reaper-plugins/reaper_atmos/CMakeLists.txt
@@ -1,21 +1,5 @@
-add_library(reaper_atmos MODULE reaper_atmos.cpp)
+include(${PROJECT_SOURCE_DIR}/cmake/ReaperPlugin.cmake)
 
-if(WIN32)
-  set_target_properties(reaper_atmos PROPERTIES SUFFIX ".dll")
-elseif(APPLE)
-  set_target_properties(reaper_atmos PROPERTIES SUFFIX ".dylib")
-else()
-  set_target_properties(reaper_atmos PROPERTIES SUFFIX ".so")
-endif()
-
-set(REAPER_SDK_ROOT ${PROJECT_SOURCE_DIR})
-set(REAPER_PLUGINS_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/..)
-
-target_include_directories(reaper_atmos PRIVATE
-  ${REAPER_PLUGINS_ROOT}
-  ${REAPER_SDK_ROOT}/sdk
-  ${REAPER_SDK_ROOT}/WDL/WDL
+add_reaper_plugin(reaper_atmos SOURCES
+  reaper_atmos.cpp
 )
-
-target_compile_features(reaper_atmos PRIVATE cxx_std_17)
-target_compile_definitions(reaper_atmos PRIVATE NOMINMAX)

--- a/reaper-plugins/reaper_csurf/CMakeLists.txt
+++ b/reaper-plugins/reaper_csurf/CMakeLists.txt
@@ -1,4 +1,6 @@
-add_library(reaper_csurf MODULE
+include(${PROJECT_SOURCE_DIR}/cmake/ReaperPlugin.cmake)
+
+add_reaper_plugin(reaper_csurf SOURCES
   csurf_main.cpp
   csurf_01X.cpp
   csurf_alphatrack.cpp
@@ -13,28 +15,3 @@ add_library(reaper_csurf MODULE
   osc.cpp
   osc_message.cpp
 )
-
-if(WIN32)
-  target_sources(reaper_csurf PRIVATE res.rc)
-  set_target_properties(reaper_csurf PROPERTIES SUFFIX ".dll")
-elseif(APPLE)
-  set_target_properties(reaper_csurf PROPERTIES SUFFIX ".dylib")
-else()
-  set_target_properties(reaper_csurf PROPERTIES SUFFIX ".so")
-endif()
-
-# Include paths for SDK and WDL
-set(REAPER_SDK_ROOT ${PROJECT_SOURCE_DIR})
-
-# reaper-plugins directory for shared headers like reaper_plugin.h
-set(REAPER_PLUGINS_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/..)
-
-target_include_directories(reaper_csurf PRIVATE
-  ${REAPER_PLUGINS_ROOT}
-  ${REAPER_SDK_ROOT}/sdk
-  ${REAPER_SDK_ROOT}/WDL/WDL
-  ${REAPER_SDK_ROOT}/WDL/swell
-)
-
-target_compile_features(reaper_csurf PRIVATE cxx_std_17)
-target_compile_definitions(reaper_csurf PRIVATE NOMINMAX)

--- a/reaper-plugins/reaper_csurf/csurf_mcu.cpp
+++ b/reaper-plugins/reaper_csurf/csurf_mcu.cpp
@@ -8,6 +8,7 @@
 
 #include "csurf.h"
 #include "../../WDL/ptrlist.h"
+#include "../../sdk/config_ini.h"
 
 /*
 MCU documentation:
@@ -759,12 +760,12 @@ class CSurf_MCU : public IReaperControlSurface
 
 	bool OnGlobal( MIDI_event_t *evt ) {
     g_csurf_mcpmode=!g_csurf_mcpmode;
-    if (m_midiout) 
+    if (m_midiout)
       m_midiout->Send(0x90, 0x33,g_csurf_mcpmode?0x7f:0,-1);
     TrackList_UpdateAllExternalSurfaces();
-    WritePrivateProfileString("csurf","mcu_mcp",g_csurf_mcpmode?"1":"0",get_ini_file());
+    config_ini::setString(get_ini_file(),"csurf","mcu_mcp",g_csurf_mcpmode?"1":"0");
     return true;
-	}
+        }
 	
 	bool OnKeyModifier( MIDI_event_t *evt ) {
 	  int mask=(1<<(evt->midi_message[1]-0x46));
@@ -1700,7 +1701,7 @@ static IReaperControlSurface *createFunc(const char *type_string, const char *co
   if (!init)
   {
     init = true;
-    g_csurf_mcpmode = !!GetPrivateProfileInt("csurf","mcu_mcp",0,get_ini_file());
+    g_csurf_mcpmode = !!config_ini::getInt(get_ini_file(),"csurf","mcu_mcp",0);
   }
 
   return new CSurf_MCU(!strcmp(type_string,"MCUEX"),parms[0],parms[1],parms[2],parms[3],parms[4],errStats);

--- a/reaper-plugins/reaper_csurf/csurf_www.cpp
+++ b/reaper-plugins/reaper_csurf/csurf_www.cpp
@@ -6,6 +6,7 @@
 #include "../../WDL/lineparse.h"
 #include "../../WDL/dirscan.h"
 #include "../../WDL/assocarray.h"
+#include "../../sdk/config_ini.h"
 
 #include "../../WDL/jnetlib/jnetlib.h"
 
@@ -592,7 +593,7 @@ public:
     {
       char fmt[32], tmp[256];
       snprintf(fmt,sizeof(fmt),"header%d",x+1);
-      GetPrivateProfileString("csurf_www",fmt,"!",tmp,sizeof(tmp),get_ini_file());
+      config_ini::getString(get_ini_file(),"csurf_www",fmt,"!",tmp,sizeof(tmp));
       if (!strcmp(tmp,"!")) break;
       if (strstr(tmp,":")) m_extra_headers.Add(strdup(tmp));
     }

--- a/reaper-plugins/reaper_mp3/CMakeLists.txt
+++ b/reaper-plugins/reaper_mp3/CMakeLists.txt
@@ -1,3 +1,5 @@
+include(${PROJECT_SOURCE_DIR}/cmake/ReaperPlugin.cmake)
+
 set(MP3_SOURCES
   mp3dec.cpp
   mp3_index.cpp
@@ -14,26 +16,4 @@ set(MP3_SOURCES
   ${PROJECT_SOURCE_DIR}/WDL/WDL/lameencdec.cpp
 )
 
-add_library(reaper_mp3 MODULE ${MP3_SOURCES})
-
-if(WIN32)
-  target_sources(reaper_mp3 PRIVATE res.rc)
-  set_target_properties(reaper_mp3 PROPERTIES SUFFIX ".dll")
-elseif(APPLE)
-  set_target_properties(reaper_mp3 PROPERTIES SUFFIX ".dylib")
-else()
-  set_target_properties(reaper_mp3 PROPERTIES SUFFIX ".so")
-endif()
-
-set(REAPER_SDK_ROOT ${PROJECT_SOURCE_DIR})
-set(REAPER_PLUGINS_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/..)
-
-target_include_directories(reaper_mp3 PRIVATE
-  ${REAPER_PLUGINS_ROOT}
-  ${REAPER_SDK_ROOT}/sdk
-  ${REAPER_SDK_ROOT}/WDL/WDL
-  ${REAPER_SDK_ROOT}/WDL/swell
-)
-
-target_compile_features(reaper_mp3 PRIVATE cxx_std_17)
-target_compile_definitions(reaper_mp3 PRIVATE NOMINMAX)
+add_reaper_plugin(reaper_mp3 SOURCES ${MP3_SOURCES})

--- a/reaper-plugins/reaper_mp3/mpglib/mpglib.h
+++ b/reaper-plugins/reaper_mp3/mpglib/mpglib.h
@@ -41,7 +41,8 @@
 
 #define sample real
 
-#if !defined(_DEBUG) && mpglib_real_size == 32
+#if !defined(_DEBUG) && mpglib_real_size == 32 && \
+    (defined(_M_IX86) || defined(__i386__) || defined(_M_X64) || defined(__x86_64__))
 #define MPGLIB_HAVE_ASM
 #endif
 

--- a/reaper-plugins/reaper_mp3/pcmsrc_mp3dec.cpp
+++ b/reaper-plugins/reaper_mp3/pcmsrc_mp3dec.cpp
@@ -22,6 +22,7 @@ void (*gOnMallocFailPtr)(int);
 #include "../../WDL/ptrlist.h"
 #include "../../WDL/assocarray.h"
 #include "../../WDL/mutex.h"
+#include "../../sdk/config_ini.h"
 
 #include "../../WDL/fileread.h"
 
@@ -1103,8 +1104,8 @@ REAPER_PLUGIN_DLL_EXPORT int REAPER_PLUGIN_ENTRYPOINT(REAPER_PLUGIN_HINSTANCE hI
         !rec->Register)
           return 0;
 
-    g_config_reapindex_minsize = GetPrivateProfileInt("REAPER","reapindex_minsize",
-        g_config_reapindex_minsize,get_ini_file());
+    g_config_reapindex_minsize = config_ini::getInt(get_ini_file(),"REAPER","reapindex_minsize",
+        g_config_reapindex_minsize);
 
     IMPORT_LOCALIZE_RPLUG(rec)
 

--- a/reaper-plugins/reaper_stt/CMakeLists.txt
+++ b/reaper-plugins/reaper_stt/CMakeLists.txt
@@ -1,21 +1,5 @@
-add_library(reaper_stt MODULE reaper_stt.cpp)
+include(${PROJECT_SOURCE_DIR}/cmake/ReaperPlugin.cmake)
 
-if(WIN32)
-  set_target_properties(reaper_stt PROPERTIES SUFFIX ".dll")
-elseif(APPLE)
-  set_target_properties(reaper_stt PROPERTIES SUFFIX ".dylib")
-else()
-  set_target_properties(reaper_stt PROPERTIES SUFFIX ".so")
-endif()
-
-set(REAPER_SDK_ROOT ${PROJECT_SOURCE_DIR})
-set(REAPER_PLUGINS_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/..)
-
-target_include_directories(reaper_stt PRIVATE
-  ${REAPER_PLUGINS_ROOT}
-  ${REAPER_SDK_ROOT}/sdk
-  ${REAPER_SDK_ROOT}/WDL/WDL
+add_reaper_plugin(reaper_stt SOURCES
+  reaper_stt.cpp
 )
-
-target_compile_features(reaper_stt PRIVATE cxx_std_17)
-target_compile_definitions(reaper_stt PRIVATE NOMINMAX)

--- a/sdk/config_ini.h
+++ b/sdk/config_ini.h
@@ -11,6 +11,9 @@ inline int getInt(const char *fn, const char *section, const char *key, int defv
 inline bool getBinary(const char *fn, const char *section, const char *key, void *data, unsigned int len) {
   return GetPrivateProfileStruct(section, key, data, len, fn) != 0;
 }
+inline void getString(const char *fn, const char *section, const char *key, const char *defval, char *buf, int bufSize) {
+  GetPrivateProfileString(section, key, defval, buf, bufSize, fn);
+}
 inline void setString(const char *fn, const char *section, const char *key, const char *value) {
   WritePrivateProfileString(section, key, value, fn);
 }
@@ -28,6 +31,7 @@ inline void setBinary(const char *fn, const char *section, const char *key, cons
 #include <filesystem>
 #include <cctype>
 #include <cstdio>
+#include <cstring>
 
 namespace config_ini {
 
@@ -127,6 +131,14 @@ inline bool getBinary(const char *fn, const char *section, const char *key, void
     out[i] = (unsigned char)byte;
   }
   return true;
+}
+inline void getString(const char *fn, const char *section, const char *key, const char *defval, char *buf, int bufSize) {
+  std::string v = readValue(std::filesystem::path(fn), section, key);
+  if (v.empty() && defval) v = defval;
+  if (bufSize > 0) {
+    std::strncpy(buf, v.c_str(), bufSize-1);
+    buf[bufSize-1] = 0;
+  }
 }
 
 inline void setString(const char *fn, const char *section, const char *key, const char *value) {


### PR DESCRIPTION
## Summary
- Replace legacy Win32 INI helpers with cross‑platform config_ini in control surface and mp3 plug-ins
- Add reusable CMake helper that links frameworks and auto-generates SWELL resources on macOS
- Guard x86-only mpglib assembly, falling back to portable C on other architectures
- Document macOS universal builds, frameworks, and SWELL resource step

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: ../../WDL/db2val.h: No such file or directory)*
- `cmake --build build --target track_playlist_demo`


------
https://chatgpt.com/codex/tasks/task_e_6896989d2bbc832c9e011c967a7a4a34