### PR TITLE
Guard mpglib x86 assembly

### DIFF
--- a/reaper-plugins/reaper_mp3/CMakeLists.txt
+++ b/reaper-plugins/reaper_mp3/CMakeLists.txt
@@ -14,6 +14,14 @@ set(MP3_SOURCES
   ${PROJECT_SOURCE_DIR}/WDL/WDL/lameencdec.cpp
 )
 
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "i[3-6]86" OR
+   CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64" OR
+   CMAKE_SYSTEM_PROCESSOR MATCHES "AMD64")
+  enable_language(ASM_NASM)
+  list(APPEND MP3_SOURCES mpglib/dct64_asm.nas)
+  set_source_files_properties(mpglib/dct64_asm.nas PROPERTIES LANGUAGE ASM_NASM)
+endif()
+
 add_library(reaper_mp3 MODULE ${MP3_SOURCES})
 
 if(WIN32)

--- a/reaper-plugins/reaper_mp3/mpglib/dct64_i386.cpp
+++ b/reaper-plugins/reaper_mp3/mpglib/dct64_i386.cpp
@@ -8,12 +8,13 @@
 
 #include "StdAfx.h"
 
-#ifdef MPGLIB_HAVE_ASM
-extern "C" 
+#if defined(MPGLIB_HAVE_ASM) && \
+    (defined(__i386__) || defined(_M_IX86) || defined(__x86_64__))
+extern "C"
 {
-	void __cdecl dct64_asm_x87(real *out0,real *out1,real *b1,real *b2,real *samples);
-	void __cdecl dct64_asm_3dnow(real *out0,real *out1,real *b1,real *b2,real *samples);
-	int __cdecl detect_3dnow_ex();
+        void __cdecl dct64_asm_x87(real *out0,real *out1,real *b1,real *b2,real *samples);
+        void __cdecl dct64_asm_3dnow(real *out0,real *out1,real *b1,real *b2,real *samples);
+        int __cdecl detect_3dnow_ex();
 };
 
 static void (__cdecl * p_dct64_asm)(real *out0,real *out1,real *b1,real *b2,real *samples) = detect_3dnow_ex() ? dct64_asm_3dnow : dct64_asm_x87;

--- a/reaper-plugins/reaper_mp3/mpglib/decode_i386.cpp
+++ b/reaper-plugins/reaper_mp3/mpglib/decode_i386.cpp
@@ -108,11 +108,12 @@ static void
     }
 }
 
-#ifdef MPGLIB_HAVE_ASM
-extern "C" 
+#if defined(MPGLIB_HAVE_ASM) && \
+    (defined(__i386__) || defined(_M_IX86) || defined(__x86_64__))
+extern "C"
 {
-	float synth_sampleconv_scale[2] = {(float)(1.0 / (double)0x8000),0};
-	float synth_sampleconv_scale_neg[2] = {(float)(- 1.0 / (double)0x8000),0};
+        float synth_sampleconv_scale[2] = {(float)(1.0 / (double)0x8000),0};
+        float synth_sampleconv_scale_neg[2] = {(float)(- 1.0 / (double)0x8000),0};
 
 	int __cdecl detect_3dnow_ex();
 

--- a/reaper-plugins/reaper_mp3/mpglib/layer3.cpp
+++ b/reaper-plugins/reaper_mp3/mpglib/layer3.cpp
@@ -26,13 +26,14 @@ static real tfcos12[3];
 
 
 
-#ifdef MPGLIB_HAVE_ASM
+#if defined(MPGLIB_HAVE_ASM) && \
+    (defined(__i386__) || defined(_M_IX86) || defined(__x86_64__))
 extern "C"
 {
-	float ms_stereo_extrascalefactor[2] = {1.0 / sqrt(2.0),1.0 / sqrt(2.0)};
-	void __cdecl do_ms_stereo_x87(real * in0,real * in1,unsigned count);
-	void __cdecl do_ms_stereo_3dnow(real * in0,real * in1,unsigned count);
-	int __cdecl detect_3dnow();
+        float ms_stereo_extrascalefactor[2] = {1.0 / sqrt(2.0),1.0 / sqrt(2.0)};
+        void __cdecl do_ms_stereo_x87(real * in0,real * in1,unsigned count);
+        void __cdecl do_ms_stereo_3dnow(real * in0,real * in1,unsigned count);
+        int __cdecl detect_3dnow();
 }
 
 typedef void (__fastcall * t_do_ms_stereo)(real * in0,real * in1,unsigned count);
@@ -1693,14 +1694,15 @@ int mpglib::do_layer3(sample *pcm_sample,int *pcm_point)
 
 		  if(ms_stereo) {
 			  profiler(mpglib_do_layer3_ms_stereo);
-#ifdef MPGLIB_HAVE_ASM
-			  p_do_ms_stereo((real*)hybridIn[0],(real*)hybridIn[1],SBLIMIT*SSLIMIT);
+#if defined(MPGLIB_HAVE_ASM) && \
+    (defined(__i386__) || defined(_M_IX86) || defined(__x86_64__))
+                          p_do_ms_stereo((real*)hybridIn[0],(real*)hybridIn[1],SBLIMIT*SSLIMIT);
 #else
-			  static const real extrascalefactor = 1.0 / sqrt(2.0);
-				int i;
-				for(i=0;i<SBLIMIT*SSLIMIT;i++) {
-					real tmp0,tmp1;
-					tmp0 = ((real *) hybridIn[0])[i] * extrascalefactor;
+                          static const real extrascalefactor = 1.0 / sqrt(2.0);
+                                int i;
+                                for(i=0;i<SBLIMIT*SSLIMIT;i++) {
+                                        real tmp0,tmp1;
+                                        tmp0 = ((real *) hybridIn[0])[i] * extrascalefactor;
 					tmp1 = ((real *) hybridIn[1])[i] * extrascalefactor;
 					((real *) hybridIn[1])[i] = tmp0 - tmp1;  
 					((real *) hybridIn[0])[i] = tmp0 + tmp1;

--- a/reaper-plugins/reaper_mp3/mpglib/mpglib.h
+++ b/reaper-plugins/reaper_mp3/mpglib/mpglib.h
@@ -41,7 +41,8 @@
 
 #define sample real
 
-#if !defined(_DEBUG) && mpglib_real_size == 32
+#if !defined(_DEBUG) && mpglib_real_size == 32 && \
+    (defined(__i386__) || defined(_M_IX86) || defined(__x86_64__))
 #define MPGLIB_HAVE_ASM
 #endif
 


### PR DESCRIPTION
## Summary
- enable mpglib's hand written assembly only on x86/x64
- fall back to pure C decoder on other architectures
- conditionally build NASM source only for x86 targets

## Testing
- `nasm -f elf64 dct64_asm.nas`
- `g++ -std=c++17 -c dct64_i386.cpp`
- `g++ -std=c++17 -D__aarch64__ -c dct64_i386.cpp`


------
https://chatgpt.com/codex/tasks/task_e_68969b774d54832c87ad2deb2cca9405