### PR TITLE
Refactor INI file access

### DIFF
--- a/reaper-plugins/reaper_csurf/csurf_mcu.cpp
+++ b/reaper-plugins/reaper_csurf/csurf_mcu.cpp
@@ -8,6 +8,7 @@
 
 #include "csurf.h"
 #include "../../WDL/ptrlist.h"
+#include "../../sdk/config_ini.h"
 
 /*
 MCU documentation:
@@ -762,7 +763,7 @@ class CSurf_MCU : public IReaperControlSurface
     if (m_midiout) 
       m_midiout->Send(0x90, 0x33,g_csurf_mcpmode?0x7f:0,-1);
     TrackList_UpdateAllExternalSurfaces();
-    WritePrivateProfileString("csurf","mcu_mcp",g_csurf_mcpmode?"1":"0",get_ini_file());
+    config_ini::setString(get_ini_file(), "csurf", "mcu_mcp", g_csurf_mcpmode?"1":"0");
     return true;
 	}
 	
@@ -1700,7 +1701,7 @@ static IReaperControlSurface *createFunc(const char *type_string, const char *co
   if (!init)
   {
     init = true;
-    g_csurf_mcpmode = !!GetPrivateProfileInt("csurf","mcu_mcp",0,get_ini_file());
+    g_csurf_mcpmode = !!config_ini::getInt(get_ini_file(), "csurf", "mcu_mcp", 0);
   }
 
   return new CSurf_MCU(!strcmp(type_string,"MCUEX"),parms[0],parms[1],parms[2],parms[3],parms[4],errStats);

--- a/reaper-plugins/reaper_csurf/csurf_www.cpp
+++ b/reaper-plugins/reaper_csurf/csurf_www.cpp
@@ -7,6 +7,8 @@
 #include "../../WDL/dirscan.h"
 #include "../../WDL/assocarray.h"
 
+#include "../../sdk/config_ini.h"
+
 #include "../../WDL/jnetlib/jnetlib.h"
 
 #define JNETLIB_WEBSERVER_WANT_UTILS
@@ -592,7 +594,7 @@ public:
     {
       char fmt[32], tmp[256];
       snprintf(fmt,sizeof(fmt),"header%d",x+1);
-      GetPrivateProfileString("csurf_www",fmt,"!",tmp,sizeof(tmp),get_ini_file());
+      config_ini::getString(get_ini_file(), "csurf_www", fmt, tmp, sizeof(tmp), "!");
       if (!strcmp(tmp,"!")) break;
       if (strstr(tmp,":")) m_extra_headers.Add(strdup(tmp));
     }

--- a/reaper-plugins/reaper_mp3/pcmsrc_mp3dec.cpp
+++ b/reaper-plugins/reaper_mp3/pcmsrc_mp3dec.cpp
@@ -16,6 +16,7 @@ void (*gOnMallocFailPtr)(int);
 #include "../reaper_plugin.h"
 #include "../../WDL/wdltypes.h"
 #include "../../sdk/reaper_plugin_functions.h"
+#include "../../sdk/config_ini.h"
 #include "../../WDL/lineparse.h"
 #include "../../WDL/wdlcstring.h"
 #include "../../WDL/wdlstring.h"
@@ -1103,8 +1104,8 @@ REAPER_PLUGIN_DLL_EXPORT int REAPER_PLUGIN_ENTRYPOINT(REAPER_PLUGIN_HINSTANCE hI
         !rec->Register)
           return 0;
 
-    g_config_reapindex_minsize = GetPrivateProfileInt("REAPER","reapindex_minsize",
-        g_config_reapindex_minsize,get_ini_file());
+    g_config_reapindex_minsize = config_ini::getInt(get_ini_file(), "REAPER", "reapindex_minsize",
+        g_config_reapindex_minsize);
 
     IMPORT_LOCALIZE_RPLUG(rec)
 

--- a/sdk/config_ini.h
+++ b/sdk/config_ini.h
@@ -11,6 +11,9 @@ inline int getInt(const char *fn, const char *section, const char *key, int defv
 inline bool getBinary(const char *fn, const char *section, const char *key, void *data, unsigned int len) {
   return GetPrivateProfileStruct(section, key, data, len, fn) != 0;
 }
+inline unsigned int getString(const char *fn, const char *section, const char *key, char *value, unsigned int value_len, const char *def_value=nullptr) {
+  return (unsigned int)GetPrivateProfileString(section, key, def_value ? def_value : "", value, value_len, fn);
+}
 inline void setString(const char *fn, const char *section, const char *key, const char *value) {
   WritePrivateProfileString(section, key, value, fn);
 }
@@ -28,6 +31,7 @@ inline void setBinary(const char *fn, const char *section, const char *key, cons
 #include <filesystem>
 #include <cctype>
 #include <cstdio>
+#include <cstring>
 
 namespace config_ini {
 
@@ -127,6 +131,19 @@ inline bool getBinary(const char *fn, const char *section, const char *key, void
     out[i] = (unsigned char)byte;
   }
   return true;
+}
+
+inline unsigned int getString(const char *fn, const char *section, const char *key, char *value, unsigned int value_len, const char *def_value=nullptr) {
+  std::string v = readValue(std::filesystem::path(fn), section, key);
+  if (v.empty() && def_value) v = def_value;
+  if (value_len > 0) {
+    size_t len = v.size();
+    if (len > value_len - 1) len = value_len - 1;
+    std::memcpy(value, v.c_str(), len);
+    value[len] = 0;
+    return (unsigned int)len;
+  }
+  return 0;
 }
 
 inline void setString(const char *fn, const char *section, const char *key, const char *value) {


### PR DESCRIPTION
## Summary
- add cross-platform `config_ini::getString` helper
- replace direct Windows INI API calls with `config_ini` wrappers
- default `config_ini::getString` parameter now uses `nullptr` for consistent behavior

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: ../../WDL/db2val.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6896a3ff0eb4832cb498cd1a4cbf60aa