### PR TITLE
docs: add governance and API freeze guidelines

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @chrislyons

--- a/DEVELOPER_ENV.md
+++ b/DEVELOPER_ENV.md
@@ -1,0 +1,6 @@
+# Developer Environment Baseline
+- CI runner: GitHub Actions `ubuntu-latest`.
+- Formatting: use language-standard tools (clang-format for C/C++; black/ruff for Python; eslint/prettier for JS/TS).
+- Static analysis: clang-tidy / ruff / eslint as applicable.
+- Phase 1 policy: non-functional refactor only — public APIs/exports MUST NOT change.
+- After Step 3 (CI), enable required status checks on `main`.

--- a/docs/ADMIN.md
+++ b/docs/ADMIN.md
@@ -1,0 +1,10 @@
+# ADMIN: Branch Protection (manual apply required)
+Go to: Settings → Branches → Add rule
+- Branch name pattern: main
+- Require a pull request before merging (1 approving review)
+- Require conversation resolution before merging
+- Require linear history: ON
+- Allow force pushes: OFF
+- Allow deletions: OFF
+- Include administrators: ON
+(We will add "Required status checks" after CI exists in Step 3.)

--- a/docs/API-FREEZE.md
+++ b/docs/API-FREEZE.md
@@ -1,0 +1,4 @@
+# API Freeze — Phase 1 Refactor
+For Phase 1, public APIs and exported symbols are frozen. Refactor must not alter behavior,
+signatures, exported names, or ABI. Any change that risks behavior drift must be deferred or
+explicitly discussed before proceeding.


### PR DESCRIPTION
## Summary
- document manual branch protection steps
- add CODEOWNERS file
- outline developer environment baseline
- note API freeze for phase 1

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896c194c644832c83140a9b2d3b8ec9